### PR TITLE
Increases default copyPaste limit of 1000 rows/columns to 1 billion

### DIFF
--- a/js/spreadsheet.js
+++ b/js/spreadsheet.js
@@ -74,6 +74,10 @@ var spreadsheet = function(options) {
     fixedRowsTop: 1,
     colHeaders: true,
     rowHeaders: true,
+    copyPaste: {
+      columnsLimit: 1000000000,
+      rowsLimit: 1000000000
+    },
     columnSorting: true,
     search: true,
     undo: false,

--- a/js/spreadsheet.js
+++ b/js/spreadsheet.js
@@ -75,7 +75,7 @@ var spreadsheet = function(options) {
     colHeaders: true,
     rowHeaders: true,
     copyPaste: {
-      columnsLimit: 1000000000,
+      columnsLimit: 1000,
       rowsLimit: 1000000000
     },
     columnSorting: true,


### PR DESCRIPTION
Ref. https://github.com/Fliplet/fliplet-studio/issues/2762