### PR TITLE
Fixes issue with jumping column width

### DIFF
--- a/js/spreadsheet.js
+++ b/js/spreadsheet.js
@@ -69,6 +69,7 @@ var spreadsheet = function(options) {
     manualColumnResize: true,
     manualColumnMove: true,
     manualRowMove: true,
+    colWidths: 250,
     minColsNumber: 1,
     minRowsNumber: 40,
     fixedRowsTop: 1,


### PR DESCRIPTION
Also tested opening after saving with huge rows. Table keeps its share and when editing the cell it focus and scroll to the end. No more jumping around.

![screen recording 2018-07-13 at 05 58 pm](https://user-images.githubusercontent.com/7046481/42704088-7b99e424-86c6-11e8-92c0-a9a65d6801d1.gif)
