### PR TITLE
Allow the data sources widget to initialise filtered by appId

### DIFF
--- a/css/interface.css
+++ b/css/interface.css
@@ -32,10 +32,26 @@ body {
   border: none;
 }
 
+#data-sources th.desc,
+#data-sources th.asc {
+  cursor: pointer;
+}
+
+#data-sources th.desc .fa-sort-amount-asc,
+#data-sources th.asc .fa-sort-amount-desc {
+  display: none;
+}
+
+#data-sources th.desc .fa-sort-amount-desc,
+#data-sources th.asc .fa-sort-amount-asc {
+  display: inline-block;
+}
+
 #data-sources td {
   border-left: none;
   border-right: none;
   border-bottom: none;
+  vertical-align: middle;
 }
 
 .controls-wrapper {

--- a/interface.html
+++ b/interface.html
@@ -11,6 +11,8 @@
           <div class="row">
             <div class="col-sm-8">
               <button data-create-source class="btn btn-primary">Create new data source</button>
+              <button data-show-all-source class="btn btn-secondary hidden">Show all data sources</button>
+              <button data-app-source class="btn btn-secondary hidden">Show app's data sources</button>
             </div>
             <div class="col-sm-4">
               <input class="search pull-right form-control" type="search" placeholder="Search data sources" />
@@ -20,8 +22,17 @@
             <thead>
               <tr>
                 <th>ID</th>
-                <th>Data source</th>
+                <th class="desc" data-order-name>
+                  Data source
+                  <i class="fa fa-sort-amount-asc"></i>
+                  <i class="fa fa-sort-amount-desc"></i>
+                </th>
                 <th>Used by apps</th>
+                <th class="desc" data-order-date>
+                  Last updated
+                  <i class="fa fa-sort-amount-asc"></i>
+                  <i class="fa fa-sort-amount-desc"></i>
+                </th>
                 <th>&nbsp;</th>
               </tr>
             </thead>

--- a/js/interface.js
+++ b/js/interface.js
@@ -44,7 +44,22 @@ function getDataSources() {
     })
     .then(function(userDataSources) {
       var html = [];
-      dataSources = userDataSources;
+
+      if (copyData.context === 'app-overlay' || copyData.app) {
+        var filteredDataSources = [];
+        userDataSources.forEach(function(dataSource, index) {
+          var matchedApp = _.find(dataSource.apps, function(app) {
+            return dataSource.appId === copyData.app.id || app.id === copyData.app.id;
+          });
+
+          if (matchedApp) {
+            filteredDataSources.push(userDataSources[index]);
+          }
+        });
+        dataSources = filteredDataSources;
+      } else {
+        dataSources = userDataSources;
+      }
       dataSources.forEach(function (dataSource) {
         html.push(getDataSourceRender(dataSource));
       });

--- a/js/interface.templates.js
+++ b/js/interface.templates.js
@@ -17,12 +17,14 @@ this["Fliplet"]["Widget"]["Templates"]["templates.dataSource"] = Handlebars.temp
 
   return "<tr class=\"data-source\" data-id=\""
     + alias4(((helper = (helper = helpers.id || (depth0 != null ? depth0.id : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"id","hash":{},"data":data}) : helper)))
-    + "\">\n    <td class=\"data-source-id\"><code>"
+    + "\">\n    <td class=\"data-source-id\">"
     + alias4(((helper = (helper = helpers.id || (depth0 != null ? depth0.id : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"id","hash":{},"data":data}) : helper)))
-    + "</code></td>\n    <td class=\"data-source-name\"><a href=\"#\" data-browse-source>"
+    + "</td>\n    <td class=\"data-source-name\"><a href=\"#\" data-browse-source>"
     + alias4(((helper = (helper = helpers.name || (depth0 != null ? depth0.name : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"name","hash":{},"data":data}) : helper)))
     + "</a></td>\n    <td class=\"data-source-apps\">"
     + ((stack1 = helpers.each.call(alias1,(depth0 != null ? depth0.apps : depth0),{"name":"each","hash":{},"fn":container.program(1, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
+    + "</td>\n    <td class=\"data-source-apps\">"
+    + alias4((helpers.momentCalendar || (depth0 && depth0.momentCalendar) || alias2).call(alias1,(depth0 != null ? depth0.updatedAt : depth0),{"name":"momentCalendar","hash":{},"data":data}))
     + "</td>\n    <td class=\"data-source-edit text-right\"><button class=\"btn btn-default\" data-browse-source>Edit</button></td>\n</tr>";
 },"useData":true});
 

--- a/templates/dataSource.interface.hbs
+++ b/templates/dataSource.interface.hbs
@@ -1,6 +1,7 @@
 <tr class="data-source" data-id="{{id}}">
-    <td class="data-source-id"><code>{{id}}</code></td>
+    <td class="data-source-id">{{id}}</td>
     <td class="data-source-name"><a href="#" data-browse-source>{{name}}</a></td>
     <td class="data-source-apps">{{#each apps}} {{name}} {{#unless @last}},{{/unless}} {{/each}}</td>
+    <td class="data-source-apps">{{momentCalendar updatedAt}}</td>
     <td class="data-source-edit text-right"><button class="btn btn-default" data-browse-source>Edit</button></td>
 </tr>


### PR DESCRIPTION
This enhancement is for when a user clicks on App Data from the right side bar in Edit, the overlay with the list of data sources, only shows the data sources used by the app.

Studio commit reference: https://github.com/Fliplet/fliplet-studio/pull/3386/commits/f5eb3d421e555ff0ee7d3e0e0efe95b16c008769

![screenshot 2018-10-31 at 13 19 53](https://user-images.githubusercontent.com/7046481/47790667-ac506d00-dd0f-11e8-97f6-714e202a0e89.png)
