### PR TITLE
User now cannot change data source name to empty (or only spaces), input gets highlighted

### DIFF
--- a/js/interface.js
+++ b/js/interface.js
@@ -637,18 +637,17 @@ $('#app')
   })
   .on('submit', 'form[data-settings]', function(event) {
     event.preventDefault();
-    var name = $settings.find('#name').val();
+    var name = $settings.find('#name').val().trim();
+
+    if (!name) {
+      $settings.find('#name').parents(':eq(1)').addClass('has-error');
+      return;
+    }
+
     var bundle = !$('#bundle').is(':checked');
     var definition = definitionEditor.getValue();
     var hooks = hooksEditor.getValue();
-
-    if (!name) {
-      Fliplet.Navigate.popup({
-        popupTitle: 'Invalid settings',
-        popupMessage: 'Name must be set'
-      });
-      return;
-    }
+    $settings.find('#name').parents(':eq(1)').removeClass('has-error');
 
     try {
       definition = JSON.parse(definition);


### PR DESCRIPTION
@tonytlwu @squallstar 

## Issue
Fliplet/fliplet-studio#4036

## Description
Added trim to name, the input gets highlighted if the name is empty.

## Screenshots/screencasts
![empty name demo](https://user-images.githubusercontent.com/52824207/67266620-4e390e80-f4b9-11e9-912d-3eb7e464a216.gif)

## Backward compatibility
This change is fully backward compatible.