### PR TITLE
Now pressing enter on data source name input not triggers delete modal

### DIFF
--- a/interface.html
+++ b/interface.html
@@ -135,7 +135,7 @@
                   <div class="form-group">
                     <label for="name" class="col-sm-4 control-label">Data source name</label>
                     <div class="col-sm-8">
-                      <input id="name" class="form-control" name="name" maxlength="48" />
+                      <input id="name" class="form-control" name="name" maxlength="48" data-input-name/>
                     </div>
                   </div>
                   <div class="form-group">

--- a/js/interface.js
+++ b/js/interface.js
@@ -621,6 +621,13 @@ $('#app')
       });
     }, 100);
   })
+  .on('keyup keypress', '[data-input-name]', function(event) {
+  var keyCode = event.keyCode || event.which;
+    if (keyCode === 13) {
+      event.preventDefault();
+      return false;
+    }
+  })
   .on('click', '[data-revoke-role]', function(event) {
     event.preventDefault();
     var userId = $(this).data('revoke-role');


### PR DESCRIPTION
@tonytlwu @squallstar 

## Issue
https://github.com/Fliplet/fliplet-studio/issues/4868

## Description
Added prevent default on enter.

## Screenshots/screencasts
Enter does not work. Nothing to show)

## Backward compatibility
This change is fully backward copmatible.

## Notes
I used both event.keyCode and event.which because I read in the documentation that sometimes event.keyCode does not work in older firefox versions. 