### PR TITLE
Now users cannot open data source in a new tab

### DIFF
--- a/css/interface.css
+++ b/css/interface.css
@@ -81,6 +81,16 @@ a[data-back] {
   align-items: flex-end;
 }
 
+.data-source-text {
+  color: #00abd1;
+}
+
+.data-source-text:hover {
+  color: #23527c;
+  text-decoration: underline;
+  cursor: pointer;
+}
+
 .editing-data-source-name {
   max-width: 100%;
   margin: 0;

--- a/js/interface.templates.js
+++ b/js/interface.templates.js
@@ -19,13 +19,13 @@ this["Fliplet"]["Widget"]["Templates"]["templates.dataSource"] = Handlebars.temp
     + alias4(((helper = (helper = helpers.id || (depth0 != null ? depth0.id : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"id","hash":{},"data":data}) : helper)))
     + "\">\n    <td class=\"data-source-id\">"
     + alias4(((helper = (helper = helpers.id || (depth0 != null ? depth0.id : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"id","hash":{},"data":data}) : helper)))
-    + "</td>\n    <td class=\"data-source-name\"><a href=\"#\" data-browse-source>"
+    + "</td>\n    <td class=\"data-source-name\"><span class=\"data-source-text\" data-browse-source>"
     + alias4(((helper = (helper = helpers.name || (depth0 != null ? depth0.name : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"name","hash":{},"data":data}) : helper)))
-    + "</a></td>\n    <td class=\"data-source-apps\">"
+    + "</span></td>\n    <td class=\"data-source-apps\">"
     + ((stack1 = helpers.each.call(alias1,(depth0 != null ? depth0.apps : depth0),{"name":"each","hash":{},"fn":container.program(1, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
     + "</td>\n    <td class=\"data-source-apps\">"
     + alias4((helpers.momentCalendar || (depth0 && depth0.momentCalendar) || alias2).call(alias1,(depth0 != null ? depth0.updatedAt : depth0),{"name":"momentCalendar","hash":{},"data":data}))
-    + "</td>\n    <td class=\"data-source-edit text-right\"><button class=\"btn btn-default\" data-browse-source>Edit</button></td>\n</tr>";
+    + "</td>\n    <td class=\"data-source-edit text-right\"><button class=\"btn btn-default\" data-browse-source>Edit</button></td>\n</tr>\n";
 },"useData":true});
 
 this["Fliplet"]["Widget"]["Templates"]["templates.overlay"] = Handlebars.template({"compiler":[7,">= 4.0.0"],"main":function(container,depth0,helpers,partials,data) {

--- a/templates/dataSource.interface.hbs
+++ b/templates/dataSource.interface.hbs
@@ -1,6 +1,6 @@
 <tr class="data-source" data-id="{{id}}">
     <td class="data-source-id">{{id}}</td>
-    <td class="data-source-name"><a href="#" data-browse-source>{{name}}</a></td>
+    <td class="data-source-name"><span class="data-source-text" data-browse-source>{{name}}</span></td>
     <td class="data-source-apps">{{#each apps}} {{name}} {{#unless @last}},{{/unless}} {{/each}}</td>
     <td class="data-source-apps">{{momentCalendar updatedAt}}</td>
     <td class="data-source-edit text-right"><button class="btn btn-default" data-browse-source>Edit</button></td>


### PR DESCRIPTION
@tonytlwu @squallstar 

## Issue
Fliplet/fliplet-studio#4295

## Description
Replaced a with span. Added necessary classes.

## Screenshots/screencasts
![new tab ](https://user-images.githubusercontent.com/52824207/67573566-530ff380-f741-11e9-810a-eca1b444ca36.gif)

## Backward compatibility
This change is fully backward compatible.