### PR TITLE
Before deleting data source modal window will show apps where this data source is used

### DIFF
--- a/js/interface.js
+++ b/js/interface.js
@@ -536,9 +536,27 @@ $('#app')
   })
   .on('click', '[data-delete-source]', function(event) {
     event.preventDefault();
-    var confirmAlert = confirm('Are you sure you want to delete this data source? All entries will be deleted.');
+    var message = 'Are you sure you want to delete this data source? All entries will be deleted.';
+    var currentDS = _.find(dataSources, function(ds) {
+      return ds.id === currentDataSourceId;
+    });
 
-    if (confirmAlert) {
+    if (currentDS.apps.length) {
+      var appPrefix = currentDS.apps.length > 1 ? 'apps: ' : 'app: ';
+      var appUsedIn = currentDS.apps.map(function(elem) {
+        return ' ' + elem.name;
+      });
+
+      message = 'Are you sure you want to delete this data source? The data source is used in the next ' + appPrefix + appUsedIn + '. All entries will be deleted.';
+    }
+
+    Fliplet.Modal.confirm({
+      message: message
+    }).then(function(result) {
+      if (!result) {
+        return;
+      }
+
       Fliplet.DataSources.delete(currentDataSourceId).then(function() {
         // Remove from UI
         $('.data-source[data-id="' + currentDataSourceId + '"]').remove();
@@ -556,7 +574,7 @@ $('#app')
         // Go back
         $('[data-back]').click();
       });
-    }
+    });
   })
   .on('click', '[data-create-source]', function(event) {
     event.preventDefault();

--- a/js/interface.js
+++ b/js/interface.js
@@ -536,7 +536,8 @@ $('#app')
   })
   .on('click', '[data-delete-source]', function(event) {
     event.preventDefault();
-    var message = 'Are you sure you want to delete this data source? All entries will be deleted.';
+    var usedAppsText = '';
+
     var currentDS = _.find(dataSources, function(ds) {
       return ds.id === currentDataSourceId;
     });
@@ -544,11 +545,12 @@ $('#app')
     if (currentDS.apps.length) {
       var appPrefix = currentDS.apps.length > 1 ? 'apps: ' : 'app: ';
       var appUsedIn = currentDS.apps.map(function(elem) {
-        return ' ' + elem.name;
+        return elem.name;
       });
-
-      message = 'Are you sure you want to delete this data source? The data source is used in the next ' + appPrefix + appUsedIn + '. All entries will be deleted.';
+      usedAppsText = 'The data source is currently in use by the following ' + appPrefix + appUsedIn.join(', ') + '. ';
     }
+
+    var message = 'Are you sure you want to delete this data source? ' + usedAppsText + 'All entries will be deleted.';
 
     Fliplet.Modal.confirm({
       message: message


### PR DESCRIPTION
## Issue
Fliplet/fliplet-studio#3774

## Description
Replaced default confirm with Fliplet.confirm. Added names of apps where the data source is used.

## Screenshots/screencasts
![deleting demo](https://user-images.githubusercontent.com/52824207/67679435-bf813180-f991-11e9-82fa-162b3f82a1fb.gif)

## Backward compatibility
This change is fully backward compatible.