### PR TITLE
Added max-height to cells, rows are now resizable

### DIFF
--- a/css/interface.css
+++ b/css/interface.css
@@ -210,6 +210,12 @@ a[data-back] {
   transition: all 0.25s ease;
 }
 
+.cell-wrapper {
+  max-height: 110px;
+  min-height: 100%;
+  overflow: hidden;
+}
+
 .mce-ico {
   display: inline-block;
   font: normal normal normal 14px/1 tinymce;

--- a/js/spreadsheet.js
+++ b/js/spreadsheet.js
@@ -82,6 +82,7 @@ var spreadsheet = function(options) {
     stretchH: 'all',
     manualColumnResize: true,
     manualColumnMove: true,
+    manualRowResize: true,
     manualRowMove: true,
     colWidths: 250,
     minColsNumber: 1,
@@ -107,6 +108,7 @@ var spreadsheet = function(options) {
       return cellProperties;
     },
     data: data,
+    renderer: addMaxHeightToCells,
     // Always have one empty row at the end
     minSpareRows: 40,
     // Hooks
@@ -279,6 +281,11 @@ var spreadsheet = function(options) {
     return name;
   }
 
+  function addMaxHeightToCells(instance, td, row, col, prop, value, cellProperties) {
+    Handsontable.renderers.TextRenderer.apply(this, arguments);
+    td.innerHTML = '<div class="cell-wrapper">' + td.innerHTML + '</div>';
+  }
+
   /**
    * Check is a row is not empty. Empty means that all elements doesn't have a value
    * @param {Array} row
@@ -335,7 +342,7 @@ var spreadsheet = function(options) {
           headers.forEach(function(header, index) {
             entry.data[header] = visualRow[index];
             entry.order = order;
-  
+
             // Cast CSV to String
             if (arrayColumns.indexOf(header) !== -1 && typeof entry.data[header] === 'string') {
               try {


### PR DESCRIPTION
@tonytlwu @squallstar 

## Issue
Fliplet/fliplet-studio#2597
Fliplet/fliplet-studio#2206

## Description
Added function that adds max-height to cell according to Tonys jsfiddle. Max-height is limited to 5 lines. Also added the possibility to resize row.

## Screenshots/screencasts
![max-height demo ](https://user-images.githubusercontent.com/52824207/67768959-469adc00-fa5c-11e9-8aa4-0dd2cfdcac9a.gif)

## Backward compatibility
This change is fully backward compatible.