### PR TITLE
Added padding column to the end of the data source so a user can resize the last cell without any trouble

### DIFF
--- a/js/interface.js
+++ b/js/interface.js
@@ -263,6 +263,16 @@ Fliplet.Widget.onSaveRequest(function() {
   saveCurrentData().then(Fliplet.Widget.complete);
 });
 
+/**
+ * We must remove null values of the row that we do not save padding columns
+ * @param {array} columns 
+ */
+function trimColumns(columns) {
+  return _.filter(columns, function(column) {
+    return column !== null;
+  })
+}
+
 function saveCurrentData() {
   var columns;
   $('[data-save]').addClass('hidden');
@@ -280,10 +290,10 @@ function saveCurrentData() {
       columns = [];
     }
   } else {
-    columns = table.getColumns();
+    columns = trimColumns(table.getColumns());
   }
 
-  var widths = table.getColWidths();
+  var widths = trimColumns(table.getColWidths());
 
   // Update column sizes in background
   Fliplet.DataSources.getById(currentDataSourceId).then(function (dataSource) {

--- a/js/spreadsheet.js
+++ b/js/spreadsheet.js
@@ -107,11 +107,14 @@ var spreadsheet = function(options) {
       return cellProperties;
     },
     data: data,
-    // Always have one empty row at the end
+    // Always have one empty row and column at the end
     minSpareRows: 40,
+    minSpareCols: 10,
     // Hooks
     beforeChange: function(changes, source) {
       // Check if the change was on columns row and validate
+      // If we change row without header we put header for this row
+      // In this case user won't lose his data if he forgot to input header
       changes.forEach(function(change) {
         if (change[0] === 0) {
           if (change[3] === change[2]) {
@@ -121,6 +124,13 @@ var spreadsheet = function(options) {
             change[3] = generateColumnName();
           }
           change[3] = validateOrFixColumnName(change[3]);
+        } else {
+          var header = hot.getCell(0, change[1]).innerHTML;
+          if (!header) {
+            var newHeader = generateColumnName();
+            newHeader = validateOrFixColumnName(newHeader);
+            hot.setDataAtCell(0, change[1], newHeader);
+          }
         }
       });
 
@@ -156,8 +166,14 @@ var spreadsheet = function(options) {
       // Set current widths to get them after column column is removed
       colWidths = getColWidths();
     },
-    beforeCreateCol: function() {
+    beforeCreateCol: function(index, amount, source) {
       // Set current widths to get them after column column is created
+      // Source auto means that column was created by lib to add empty col at the end of the table
+      // If we return false/undefined column will not be created
+      if (source === 'auto') {
+        return true; 
+      }
+      
       colWidths = getColWidths();
     },
     afterColumnMove: function() {
@@ -181,6 +197,11 @@ var spreadsheet = function(options) {
       onChanges();
     },
     afterCreateCol: function(index, amount, source) {
+      // Source auto means that column was created by lib to add empty col at the end of the table
+      if (source === 'auto') {
+        return true;
+      }
+
       // Column name
       for (var i = 0; i < amount; i++) {
         var columnName = generateColumnName();
@@ -333,6 +354,10 @@ var spreadsheet = function(options) {
         if (_.isEqual(sortedVisual, sortedPhysical)) {
           var entry = { id: physical[i].id, data: {} };
           headers.forEach(function(header, index) {
+            if (header === null) {
+              return;
+            }
+            
             entry.data[header] = visualRow[index];
             entry.order = order;
   


### PR DESCRIPTION
@tonytlwu @squallstar 
## Issue
https://github.com/Fliplet/fliplet-studio/issues/4864
https://github.com/Fliplet/fliplet-studio/issues/3161

## Description
Added padding column to the end of the data source so a user can resize the last cell without any trouble

## Screenshots/screencasts
![issue-4864-3161](https://user-images.githubusercontent.com/53430352/67941583-9c978d00-fbde-11e9-934c-e55ef0e60df5.gif)

## Backward compatibility

This change is fully backward compatible.

## Notes
To avoid any problem with saving data sources. When a user enters data into an empty column we will automatically add a column header.