### PR TITLE
User can edit large data sources

### DIFF
--- a/js/spreadsheet.js
+++ b/js/spreadsheet.js
@@ -126,7 +126,7 @@ var spreadsheet = function(options) {
           }
           change[3] = validateOrFixColumnName(change[3]);
         } else {
-          var header = hot.getCell(0, change[1]).innerHTML;
+          var header = getColumns()[change[1]];
           if (!header) {
             var newHeader = generateColumnName();
             newHeader = validateOrFixColumnName(newHeader);


### PR DESCRIPTION
@sofiiakvasnevska 
## Issue
https://github.com/Fliplet/fliplet-studio/issues/5304

## Description
User can edit large data sources

## Screenshots/screencasts
![edit-data-source](https://user-images.githubusercontent.com/53430352/68848251-a938dc80-06d8-11ea-92cb-ddf198ac0cf1.gif)


## Backward compatibility

This change is fully backward compatible.

## Notes
This issue occurs because when the `handsontable` get cell data through the `getCell` method we can't get data from the cell witch was scrolled on the page. But with the help of the `getColumns` method, we get only data source headers, not specific cells.