### PR TITLE
User is now able to delete data source that is not used by any app from data source overlay

### DIFF
--- a/js/interface.js
+++ b/js/interface.js
@@ -585,7 +585,7 @@ $('#app')
       return ds.id === currentDataSourceId;
     });
 
-    if (currentDS.apps.length) {
+    if (currentDS && currentDS.apps.length) {
       var appPrefix = currentDS.apps.length > 1 ? 'apps: ' : 'app: ';
       var appUsedIn = currentDS.apps.map(function(elem) {
         return elem.name;


### PR DESCRIPTION
@sofiiakvasnevska 

## Issue
https://github.com/Fliplet/fliplet-studio/issues/5306

## Description
When user is trying to delete a data source from data source overlay that is not used by any app variable 'currentDS' comes as undefined. Added extra check for it.

## Screenshots/screencasts
![ds-delete-fix](https://user-images.githubusercontent.com/52824207/69012031-9a248980-0979-11ea-8e06-e090c5644a80.gif)

## Backward compatibility
This change is fully backward compatible.