### PR TITLE
When we press ctrl + a key combination we will select only cells with data in them

### DIFF
--- a/js/spreadsheet.js
+++ b/js/spreadsheet.js
@@ -17,7 +17,6 @@ var spreadsheet = function(options) {
   var arrayColumns = [];
   var columnNameCounter = 1; // Counter to anonymous columns names
   var rendered = 0;
-  
   dataStack = [];
   currentDataStackIndex = 0;
 

--- a/js/spreadsheet.js
+++ b/js/spreadsheet.js
@@ -16,7 +16,6 @@ var spreadsheet = function(options) {
   var dataLoaded = false;
   var arrayColumns = [];
   var columnNameCounter = 1; // Counter to anonymous columns names
-  
   dataStack = [];
   currentDataStackIndex = 0;
 

--- a/js/spreadsheet.js
+++ b/js/spreadsheet.js
@@ -16,7 +16,8 @@ var spreadsheet = function(options) {
   var dataLoaded = false;
   var arrayColumns = [];
   var columnNameCounter = 1; // Counter to anonymous columns names
-
+  var lastKey;
+  
   dataStack = [];
   currentDataStackIndex = 0;
 
@@ -225,6 +226,21 @@ var spreadsheet = function(options) {
     },
     afterSelectionEnd: function(r, c, r2, c2) {
       s = [r, c, r2, c2];
+    },
+    beforeKeyDown: function (event) {
+      if ((lastKey === 17 || lastKey === 91) && event.keyCode === 65 ) {
+        event.stopImmediatePropagation();
+        
+        var colEnd = getColumns().filter(function(column) {
+          return column;
+        }).length - 1;
+        var rowEnd = getData().length;
+
+        hot.deselectCell();
+        hot.selectCells([[0, 0, rowEnd, colEnd]], false, false);
+        return false;
+      }
+      lastKey = event.keyCode;
     }
   };
 

--- a/js/spreadsheet.js
+++ b/js/spreadsheet.js
@@ -249,9 +249,10 @@ var spreadsheet = function(options) {
       if ((event.ctrlKey || event.metaKey) && event.keyCode === 65 ) {
         event.stopImmediatePropagation();
         
-        var colEnd = getColumns().filter(function(column) {
+        var cols = getColumns().filter(function(column) {
           return column;
-        }).length - 1;
+        }).length
+        var colEnd = cols ? cols - 1: cols;
         var rowEnd = getData().length;
 
         hot.deselectCell();

--- a/js/spreadsheet.js
+++ b/js/spreadsheet.js
@@ -17,6 +17,7 @@ var spreadsheet = function(options) {
   var arrayColumns = [];
   var columnNameCounter = 1; // Counter to anonymous columns names
   var rendered = 0;
+
   dataStack = [];
   currentDataStackIndex = 0;
 

--- a/js/spreadsheet.js
+++ b/js/spreadsheet.js
@@ -17,7 +17,6 @@ var spreadsheet = function(options) {
   var arrayColumns = [];
   var columnNameCounter = 1; // Counter to anonymous columns names
   var rendered = 0;
-  var isEditing = false;
 
   dataStack = [];
   currentDataStackIndex = 0;

--- a/js/spreadsheet.js
+++ b/js/spreadsheet.js
@@ -251,7 +251,7 @@ var spreadsheet = function(options) {
         
         var cols = getColumns().filter(function(column) {
           return column;
-        }).length
+        }).length;
         var colEnd = cols ? cols - 1: cols;
         var rowEnd = getData().length;
 

--- a/js/spreadsheet.js
+++ b/js/spreadsheet.js
@@ -17,6 +17,7 @@ var spreadsheet = function(options) {
   var arrayColumns = [];
   var columnNameCounter = 1; // Counter to anonymous columns names
   var rendered = 0;
+  var isEditing = false;
 
   dataStack = [];
   currentDataStackIndex = 0;
@@ -244,6 +245,10 @@ var spreadsheet = function(options) {
       s = [r, c, r2, c2];
     },
     beforeKeyDown: function (event) {
+      if (hot.getActiveEditor()._opened){
+        return;
+      }
+
       event = event || window.event;
 
       if ((event.ctrlKey || event.metaKey) && event.keyCode === 65 ) {

--- a/js/spreadsheet.js
+++ b/js/spreadsheet.js
@@ -252,7 +252,7 @@ var spreadsheet = function(options) {
         var cols = getColumns().filter(function(column) {
           return column;
         }).length;
-        var colEnd = cols ? cols - 1: cols;
+        var colEnd = Math.max(cols - 1, 0);
         var rowEnd = getData().length;
 
         hot.deselectCell();

--- a/js/spreadsheet.js
+++ b/js/spreadsheet.js
@@ -16,7 +16,6 @@ var spreadsheet = function(options) {
   var dataLoaded = false;
   var arrayColumns = [];
   var columnNameCounter = 1; // Counter to anonymous columns names
-  var lastKey;
   
   dataStack = [];
   currentDataStackIndex = 0;
@@ -228,7 +227,9 @@ var spreadsheet = function(options) {
       s = [r, c, r2, c2];
     },
     beforeKeyDown: function (event) {
-      if ((lastKey === 17 || lastKey === 91) && event.keyCode === 65 ) {
+      event = event || window.event;
+
+      if ((event.ctrlKey || event.metaKey) && event.keyCode === 65 ) {
         event.stopImmediatePropagation();
         
         var colEnd = getColumns().filter(function(column) {
@@ -240,7 +241,6 @@ var spreadsheet = function(options) {
         hot.selectCells([[0, 0, rowEnd, colEnd]], false, false);
         return false;
       }
-      lastKey = event.keyCode;
     }
   };
 


### PR DESCRIPTION
@sofiiakvasnevska 
## Issue
https://github.com/Fliplet/fliplet-studio/issues/2480

## Description
When we press ctrl + a key combination we will select only cells with data in them

## Screenshots/screencasts
![issue-2480](https://user-images.githubusercontent.com/53430352/69157350-7a15d700-0aed-11ea-9d7d-9872b998da59.gif)

## Backward compatibility

This change is fully backward compatible.