### PR TITLE
When a user select any tab except the entries and the quit and return to the data source again he will see the entries tab

### DIFF
--- a/interface.html
+++ b/interface.html
@@ -1,14 +1,9 @@
 <div id="app">
   <!-- Show loading data label -->
-  <div class="label label-success loading-data" style="display:none;">Loading data...</div>
+  <div class="label label-success loading-data">Loading data...</div>
   <div class="container-fluid">
     <div class="row">
       <div class="col-xs-12">
-        <!-- Show loading animation -->
-        <div class="spinner-holder inital-state text-center animated">
-          <div class="spinner-overlay">Loading...</div>
-          <p>Loading...</p>
-        </div>
         <div id="contents" class="hidden">
           <div class="row">
             <div class="col-sm-8">

--- a/js/interface.js
+++ b/js/interface.js
@@ -330,6 +330,7 @@ function browseDataSource(id) {
   currentDataSourceId = id;
   $contents.addClass('hidden');
   $('.settings-btns').removeClass('active');
+  $initialSpinnerLoading.removeClass('animated');
   // Hide nav tabs and tooltip bar
   var tab = $sourceContents.find('ul.nav.nav-tabs li');
 
@@ -554,6 +555,7 @@ $('#app')
   })
   .on('click', '[data-back]', function(event) {
     event.preventDefault();
+    $('[href="#entries"]').click();
     if (!dataSourceEntriesHasChanged || confirm('Are you sure? Changes that you made may not be saved.')) {
       try{
         table.destroy();

--- a/js/interface.js
+++ b/js/interface.js
@@ -339,10 +339,10 @@ function browseDataSource(id) {
     }
   });
 
+  $('[href="#entries"]').click();
   $sourceContents.find('#toolbar').hide();
   $('.loading-data').show();
   $sourceContents.removeClass('hidden');
-  $('.entries-message').html('<br>Loading data...');
 
   // Input file temporarily disabled
   // $contents.append('<form>Import data: <input type="file" /></form><hr /><div id="entries"></div>');
@@ -353,7 +353,6 @@ function browseDataSource(id) {
       fetchCurrentDataSourceDetails()
     ])
     .then(function() {
-      $('[href="#entries"]').click();
       windowResized();
 
       if (copyData.context === 'overlay') {
@@ -875,7 +874,10 @@ $('#app')
         } catch(e) {}
       }
     } else {
-      hot.render();
+      if (hot.container !== null) {
+        hot.render();
+      }
+
       $('.save-btn').removeClass('hidden');
       $('.back-name-holder').removeClass('hide-date');
       $('.controls-wrapper').removeClass('data-settings data-roles');

--- a/js/interface.js
+++ b/js/interface.js
@@ -1,4 +1,4 @@
-var $initialSpinnerLoading = $('.spinner-holder.inital-state');
+var $initialSpinnerLoading = $('.loading-data');
 var $contents = $('#contents');
 var $sourceContents = $('#source-contents');
 var $dataSources = $('#data-sources > tbody');
@@ -34,7 +34,7 @@ var definitionEditor = CodeMirror.fromTextArea($('#definition')[0], {
 
 // Fetch all data sources
 function getDataSources() {
-  $initialSpinnerLoading.addClass('animated');
+  $initialSpinnerLoading.show();
   $contents.addClass('hidden');
   $sourceContents.addClass('hidden');
   $('[data-save]').addClass('hidden');
@@ -114,7 +114,7 @@ function renderDataSources(dataSources) {
   });
 
   $dataSources.html(html.join(''));
-  $initialSpinnerLoading.removeClass('animated');
+  $initialSpinnerLoading.hide();
   $contents.removeClass('hidden');
 }
 
@@ -330,7 +330,6 @@ function browseDataSource(id) {
   currentDataSourceId = id;
   $contents.addClass('hidden');
   $('.settings-btns').removeClass('active');
-  $initialSpinnerLoading.removeClass('animated');
   // Hide nav tabs and tooltip bar
   var tab = $sourceContents.find('ul.nav.nav-tabs li');
 


### PR DESCRIPTION
@sofiiakvasnevska 
## Issue
https://github.com/Fliplet/fliplet-studio/issues/3113

## Description
When a user selects any tab except the entries and the quit and returns to the data source again he will see the entries tab.
Fix the second loader when data source called as an overlay

## Screenshots/screencasts
![DSSettings-tab](https://user-images.githubusercontent.com/53430352/69622169-1fc6ca00-1049-11ea-81a9-d72045ba61e2.gif)

Fix the second loader when data source called as an overlay
Before
![before update](https://user-images.githubusercontent.com/53430352/69622176-25bcab00-1049-11ea-8bce-339890cd7b59.gif)

After
![after update](https://user-images.githubusercontent.com/53430352/69622182-281f0500-1049-11ea-9ccb-a1b903e0784c.gif)


## Backward compatibility

This change is fully backward compatible.

## Note

Need to be tested on a large amount of data.