### PR TITLE
The column will save its width when the user deletes a column to the left of it.

### DIFF
--- a/js/spreadsheet.js
+++ b/js/spreadsheet.js
@@ -404,8 +404,9 @@ var spreadsheet = function(options) {
     },
     afterRemoveCol: function(index, amount) {
       // Remove columns widths from the widths array
-      //
       colWidths.splice(index, amount);
+
+      hot.updateSettings({ colWidths: colWidths })
       onChanges();
     },
     beforePaste: function(data, coords) {


### PR DESCRIPTION
@sofiiakvasnevska 

## Issue
https://github.com/Fliplet/fliplet-studio/issues/5278

## Description
The column will save its width when the user deletes a column to the left of it.

## Screenshots/screencasts
https://share.getcloudapp.com/z8uxJwm1

## Backward compatibility

This change is fully backward compatible.