### PR TITLE
Saving columns width when deleting column before. After column was manually resized

### DIFF
--- a/js/spreadsheet.js
+++ b/js/spreadsheet.js
@@ -406,7 +406,10 @@ var spreadsheet = function(options) {
       // Remove columns widths from the widths array
       colWidths.splice(index, amount);
 
+      hot.getSettings().manualColumnResize = false;
       hot.updateSettings({ colWidths: colWidths })
+      hot.getSettings().manualColumnResize = true;
+      hot.updateSettings({});
       onChanges();
     },
     beforePaste: function(data, coords) {


### PR DESCRIPTION
@sofiiakvasnevska 

## Issue
https://github.com/Fliplet/fliplet-studio/issues/5278

## Description
Saving columns width when deleting a column before. After the column was manually resized

## Screenshots/screencasts
https://share.getcloudapp.com/WnuGKDjK

## Backward compatibility

This change is fully backward compatible.

## Notes
The solution was taken from this [issue](https://github.com/handsontable/handsontable/issues/3386)

## Reviewers 
@upplabs-alex-levchenko @MaksymShokin 