### PR TITLE
ID-1026 [Maintenance] Speeds up initialization of Handsontable

### DIFF
--- a/js/interface.js
+++ b/js/interface.js
@@ -35,6 +35,7 @@ var dataSourceEntriesHasChanged = false;
 var isShowingAll = false;
 var columns;
 var dataSourcesToSearch = [];
+var initialLoad = true;
 
 var defaultAccessRules = [
   { type: ['select', 'insert', 'update', 'delete'], allow: 'all' }
@@ -324,10 +325,25 @@ function fetchCurrentDataSourceEntries(entries) {
     currentDataSourceRowsCount = rows.length;
     currentDataSourceColumnsCount = columns.length;
 
-    table = spreadsheet({ columns: columns, rows: rows });
-    $('.table-entries').css('visibility', 'visible');
+    // On initial load, create an empty spreadsheet as this speeds up subsequent loads
+    if (initialLoad) {
+      table = spreadsheet({ columns: columns, rows: [], initialLoad: true });
 
-    $('#versions').removeClass('hidden');
+      setTimeout(function() {
+        table.destroy();
+        initialLoad = false;
+
+        table = spreadsheet({ columns: columns, rows: rows });
+        $('.table-entries').css('visibility', 'visible');
+
+        $('#versions').removeClass('hidden');
+      }, 0);
+    } else {
+      table = spreadsheet({ columns: columns, rows: rows });
+      $('.table-entries').css('visibility', 'visible');
+
+      $('#versions').removeClass('hidden');
+    }
   })
     .catch(function onFetchError(error) {
       var message = error;

--- a/js/interface.js
+++ b/js/interface.js
@@ -310,9 +310,15 @@ function fetchCurrentDataSourceEntries(entries) {
     } else {
       $('#show-versions').show();
 
+      // Add an empty object in the beginning for _.extend
+      rows.unshift({});
+
       var computedColumns = _.keys(_.extend.apply({}, rows.map(function(row) {
         return row.data;
       })));
+
+      // Remove the first entry
+      rows.shift();
 
       if (computedColumns.length !== columns.length) {
         // TODO: Add tracking to verify how often this happens and why

--- a/js/interface.js
+++ b/js/interface.js
@@ -309,19 +309,16 @@ function fetchCurrentDataSourceEntries(entries) {
     } else {
       $('#show-versions').show();
 
-      // Let's make sure we get all the columns checking all rows
-      // and add any missing column to the datasource columns
-      rows.forEach(function addMissingColumns(row) {
-        Object.keys(row.data).forEach(function addColumn(column) {
-          if (columns.indexOf(column) > -1) {
-            return;
-          }
+      var computedColumns = _.keys(_.extend.apply({}, rows.map(function(row) {
+        return row.data;
+      })));
 
-          // TODO: Add tracking to verify how often this happens and why
-          // Missing column found
-          columns.push(column);
-        });
-      });
+      if (computedColumns.length !== columns.length) {
+        // TODO: Add tracking to verify how often this happens and why
+        // Missing column found
+      }
+
+      columns = _.uniq(_.concat(columns, computedColumns));
     }
 
     currentDataSourceRowsCount = rows.length;

--- a/js/spreadsheet.js
+++ b/js/spreadsheet.js
@@ -701,7 +701,13 @@ var spreadsheet = function(options) {
 
   function addMaxHeightToCells(instance, td, row, col, prop, value, cellProperties) {
     Handsontable.renderers.TextRenderer.apply(this, arguments);
-    td.innerHTML = '<div class="cell-wrapper">' + td.innerHTML + '</div>';
+
+    var wrapper = document.createElement('div');
+
+    wrapper.classList.add('cell-wrapper');
+    wrapper.innerHTML = td.innerHTML;
+
+    td.replaceChildren(wrapper);
   }
 
   /**

--- a/js/spreadsheet.js
+++ b/js/spreadsheet.js
@@ -362,6 +362,29 @@ var spreadsheet = function(options) {
       rowsLimit: 1000000000
     },
     columnSorting: true,
+    sortFunction: function sortData(sortOrder, columnMeta) {
+      return function(a, b) {
+        var plugin = hot.getPlugin('columnSorting');
+        var sortFunction;
+
+        if (a[0] === 0) {
+          return -1;
+        }
+
+        switch (columnMeta.type) {
+          case 'date':
+            sortFunction = plugin.dateSort;
+            break;
+          case 'numeric':
+            sortFunction = plugin.numericSort;
+            break;
+          default:
+            sortFunction = plugin.defaultSort;
+        }
+
+        return sortFunction(sortOrder, columnMeta)(a, b);
+      };
+    },
     search: true,
     undo: false,
     sortIndicator: true,
@@ -585,34 +608,6 @@ var spreadsheet = function(options) {
 
   dataStack.push({ data: _.cloneDeep(data) });
   hot = new Handsontable(document.getElementById('hot'), hotSettings);
-
-  // Set a sort function using Handsontable columnSorting plugin
-  hot.updateSettings({
-    colWidths: hotSettings.colWidths,
-    sortFunction: function(sortOrder, columnMeta) {
-      return function(a, b) {
-        var plugin = hot.getPlugin('columnSorting');
-        var sortFunction;
-
-        if (a[0] === 0) {
-          return -1;
-        }
-
-        switch (columnMeta.type) {
-          case 'date':
-            sortFunction = plugin.dateSort;
-            break;
-          case 'numeric':
-            sortFunction = plugin.numericSort;
-            break;
-          default:
-            sortFunction = plugin.defaultSort;
-        }
-
-        return sortFunction(sortOrder, columnMeta)(a, b);
-      };
-    }
-  });
 
   // Initialize colWidths if they wasn't stored locally
   if (!colWidths) {

--- a/js/spreadsheet.js
+++ b/js/spreadsheet.js
@@ -345,6 +345,12 @@ var spreadsheet = function(options) {
     td.classList.add('column-header-cell');
   }
 
+  var getColWidths = function() {
+    return hot.getColHeader().map(function(header, index) {
+      return hot.getColWidth(index);
+    });
+  };
+
   var hotSettings = {
     stretchH: 'all',
     manualColumnResize: true,
@@ -610,7 +616,7 @@ var spreadsheet = function(options) {
   hot = new Handsontable(document.getElementById('hot'), hotSettings);
 
   // Initialize colWidths if they wasn't stored locally
-  if (!colWidths) {
+  if (!colWidths || !colWidths.length) {
     colWidths = getColWidths();
   }
 
@@ -719,12 +725,6 @@ var spreadsheet = function(options) {
       return field;
     });
   }
-
-  var getColWidths = function() {
-    return hot.getColHeader().map(function(header, index) {
-      return hot.getColWidth(index);
-    });
-  };
 
   var getData = function(options) {
     options = options || { removeEmptyRows: true };

--- a/js/spreadsheet.js
+++ b/js/spreadsheet.js
@@ -571,7 +571,10 @@ var spreadsheet = function(options) {
     },
     afterLoadData: function(firstTime) {
       dataLoaded = true;
-      $('.entries-message').html('');
+
+      if (!options.initialLoad) {
+        $('.entries-message').html('');
+      }
     },
     afterSelectionEnd: function(r, c, r2, c2) {
       s = [r, c, r2, c2];


### PR DESCRIPTION
Ref. https://weboo.atlassian.net/browse/ID-1026

- Speeds up computation of unique column names by 4~5x https://jsbench.me/p3koki07ry/2
- Reduces Handsontable initialisation time by ~33% by avoiding a re-render right after initialisation
- Reduces time spent in custom render functions by ~50% using a more efficient wrapping function
- More accurately use column header widths
- On initial render, loads an empty Handsontable before loading data. This speeds up load time from ~160 seconds to ~5 seconds for 10k entries.

## Results

Includes changes from https://github.com/Fliplet/fliplet-widget-data-source/pull/137/commits/7072b6477915e173c4b059784a4840577238384b from [this PR](https://github.com/Fliplet/fliplet-widget-data-source/pull/137)

### Rendering 200 entries

<details>
<summary>Before (~5 seconds)</summary>

![image](https://user-images.githubusercontent.com/290733/117887798-28e14080-b2a9-11eb-8eee-3713132d7439.png)
</details>

<details>
<summary>After (~2 seconds)</summary>

![image](https://user-images.githubusercontent.com/290733/117887810-2e3e8b00-b2a9-11eb-91fe-498b88b0f3c7.png)
</details>

### Rendering 10k entries

<details>
<summary>Before (~160 seconds)</summary>

Profiler tool wasn't able to profile for more than 1.5 minutes.

![image](https://user-images.githubusercontent.com/290733/117893473-65656a00-b2b2-11eb-9119-60b5d1efd393.png)

</details>

<details>
<summary>After (~6 seconds)</summary>

![image](https://user-images.githubusercontent.com/290733/117903764-0ca0cc00-b2c8-11eb-945f-9ac67efd7803.png)

</details>