### PR TITLE
OD-389 [Fix] Hiding one of the help links for Data source manager when opened through a modal window.

### DIFF
--- a/js/interface.js
+++ b/js/interface.js
@@ -2,6 +2,7 @@ var $initialSpinnerLoading = $('.spinner-holder');
 var $contents = $('#contents');
 var $sourceContents = $('#source-contents');
 var $dataSources = $('#data-sources > tbody');
+var $helpIcon = $('.help-icon');
 var $trashedDataSources = $('#trash-sources > tbody');
 var $usersContents = $('#users');
 var $versionsContents = $('#versions-list');
@@ -93,6 +94,7 @@ function getDataSources() {
         $btnShowAllSource.removeClass('hidden');
         $('[data-app-source]').addClass('hidden');
         $('[data-back]').text('See all my app\'s data sources');
+        $helpIcon.addClass('hidden');
 
         // Filters data sources
         var filteredDataSources = [];


### PR DESCRIPTION
@romanyosyfiv @inna-bieshulia

OD-389 https://weboo.atlassian.net/browse/OD-389

## Description
**Problem:** When opening the Data Source list through a modal window, two help links are displayed.
**Solution:** When opening the Data Source list through a modal window, a "hidden" class is added for the link near the search input to hide it.

## Screenshots/screencasts
https://storyxpress.co/video/kv846ctvs1z4mq69y

## Backward compatibility
This change is fully backward compatible.

## Reviewers
@upplabs-alex-levchenko