### PR TITLE
OD-563 [Fix] Fixed scrolling to a cell after sorting

### DIFF
--- a/js/spreadsheet.js
+++ b/js/spreadsheet.js
@@ -972,6 +972,8 @@ function search(action, options) {
 
     hot.render();
   } else if (action === 'next' || action === 'prev') {
+    hot.selection.selectedHeader.cols = false;
+
     if (action === 'next') {
       queryResultIndex++;
 


### PR DESCRIPTION
@romanyosyfiv

OD-563 https://weboo.atlassian.net/browse/OD-563

## Description
**Problem**: Scrolling was not possible because the focus on the header cell was not removed
**Solution**: Before moving to the next body cell, the focus on the header cell is turned off

## Screenshots/screencasts
https://user-images.githubusercontent.com/86256215/144256925-c0c62d5b-ddc7-48c4-a370-a648bad6a6ea.mp4

Backward compatibility
This change is fully backward compatible.

## Reviewers
@upplabs-alex-levchenko