### PR TITLE
XOR-7 [FEAT] Ensure excludeTypes param added in datasource GET call

### DIFF
--- a/js/interface.js
+++ b/js/interface.js
@@ -83,7 +83,7 @@ function getDataSources() {
   return Fliplet.DataSources.get({
     roles: 'publisher,editor',
     type: null,
-    excludeTypes: 'bookmarks,likes,comments'
+    excludeTypes: 'bookmarks,likes,comments,menu'
   }, {
     cache: false
   })
@@ -742,7 +742,7 @@ function browseDataSource(id) {
         attributes: 'id,name,bundle,createdAt,updatedAt,appId,apps',
         roles: 'publisher,editor',
         type: null,
-        excludeTypes: 'bookmarks,likes,comments'
+        excludeTypes: 'bookmarks,likes,comments,menu'
       }, {
         cache: false
       })

--- a/js/interface.js
+++ b/js/interface.js
@@ -82,7 +82,8 @@ function getDataSources() {
 
   return Fliplet.DataSources.get({
     roles: 'publisher,editor',
-    type: null
+    type: null,
+    excludeTypes: 'bookmarks,likes,comments'
   }, {
     cache: false
   })
@@ -740,7 +741,8 @@ function browseDataSource(id) {
       Fliplet.DataSources.get({
         attributes: 'id,name,bundle,createdAt,updatedAt,appId,apps',
         roles: 'publisher,editor',
-        type: null
+        type: null,
+        excludeTypes: 'bookmarks,likes,comments'
       }, {
         cache: false
       })


### PR DESCRIPTION
### Product areas affected

API - GET `v1/data-sources` API 

### What does this PR do?

Update GET `v1/data-sources` API - add excludeTypes query param support which can accept data source type separated by comma e.g. excludeTypes=bookmarks,likes,comments,menu

### JIRA ticket

[XOR-7](https://weboo.atlassian.net/browse/XOR-7)

### Result



https://user-images.githubusercontent.com/101858104/174721701-70eae059-52e5-466e-a260-934c2799db1d.mp4


### Checklist

None

### Deployment instructions

None

### Author concerns

None