### PR TITLE
XOR-325 [feat] Ensure user can see Cancel button on Create/Edit Security Rule

### DIFF
--- a/interface.html
+++ b/interface.html
@@ -388,6 +388,7 @@
       </div>
       <div class="modal-footer">
         <button data-save-rule type="button" class="btn btn-primary" disabled>Confirm</button>
+        <button data-cancel type="button" class="btn btn-default">Cancel</button>
       </div>
     </div><!-- /.modal-content -->
   </div><!-- /.modal-dialog -->

--- a/js/interface.js
+++ b/js/interface.js
@@ -2294,3 +2294,10 @@ if (widgetData.context === 'overlay') {
 } else {
   getDataSources();
 }
+
+$('[data-cancel]').click(function(event) {
+  event.preventDefault();
+
+  $('[data-dismiss="modal"]').click();
+})
+

--- a/js/interface.js
+++ b/js/interface.js
@@ -2299,5 +2299,5 @@ $('[data-cancel]').click(function(event) {
   event.preventDefault();
 
   $('[data-dismiss="modal"]').click();
-})
+});
 


### PR DESCRIPTION
**Product areas affected**
Widget Data Source -> App Data -> Select DataSource -> Security Rule -> Add/Edit security Rule -> Cancel button

**What does this PR do?**
In this PR we have added Cancel button for Create / Edit Security Rule dialog box. On click of Cancel button dialog box is closing.  

**JIRA ticket**
[click here](https://weboo.atlassian.net/browse/XOR-325)

**Result**
![image](https://user-images.githubusercontent.com/108272606/180784561-0aeb18c1-6ad8-4ac7-ac0c-9a090ff6878f.png)

**Checklist**
None

**Testing instructions**
None

**Deployment instructions**
None

**Author concerns**
None