### PR TITLE
ID-2451 [Fix] Ensure show versions button is shown when the data source is empty

### DIFF
--- a/js/interface.js
+++ b/js/interface.js
@@ -321,9 +321,9 @@ function fetchCurrentDataSourceEntries(entries) {
       cacheOriginalEntries(rows);
     }, 0);
 
-    if ((!rows || !rows.length) && (!columns || !columns.length)) {
-      $('#show-versions').hide();
+    $('#show-versions').show();
 
+    if ((!rows || !rows.length) && (!columns || !columns.length)) {
       rows = [{
         data: {
           'Column 1': 'demo data',
@@ -337,8 +337,6 @@ function fetchCurrentDataSourceEntries(entries) {
       }];
       columns = ['Column 1', 'Column 2'];
     } else {
-      $('#show-versions').show();
-
       var flattenedColumns = {};
       rows.map(({data}) => data).forEach(dataItem => (flattenedColumns = {...flattenedColumns, ...dataItem}));
 


### PR DESCRIPTION
The data source version history tab is shown when the data source contains data. However, if the data source has been cleared it doesn't show up anymore, so the user is not able to restore it when it has been wiped.

I changed the functionality so that the tab is shown at all times.