### PR TITLE
XOR-431 [Fix] Ensure DS security rules retain the correct column widths when dragging

### DIFF
--- a/js/interface.js
+++ b/js/interface.js
@@ -2092,6 +2092,12 @@ $('#show-access-rules').click(function() {
       axis: 'y',
       forcePlaceholderSize: true,
       revert: 150,
+      helper: function(e, ui) {
+        ui.children().each(function() {
+          $(this).width($(this).width());
+        });
+        return ui;
+      },
       update: function() {
         var result = $(this).sortable('toArray', { attribute: 'data-rule-index' });
 

--- a/js/interface.js
+++ b/js/interface.js
@@ -2157,6 +2157,7 @@ $('#show-access-rules').click(function() {
         row.children().each(function() {
           $(this).width($(this).width());
         });
+
         return row;
       },
       update: function() {

--- a/js/interface.js
+++ b/js/interface.js
@@ -2153,11 +2153,11 @@ $('#show-access-rules').click(function() {
       forcePlaceholderSize: true,
       forceHelperSize: true,
       revert: 150,
-      helper: function(e, ui) {
-        ui.children().each(function() {
+      helper: function(event, row) {
+        row.children().each(function() {
           $(this).width($(this).width());
         });
-        return ui;
+        return row;
       },
       update: function() {
         var result = $(this).sortable('toArray', { attribute: 'data-rule-index' });

--- a/js/interface.js
+++ b/js/interface.js
@@ -2091,6 +2091,7 @@ $('#show-access-rules').click(function() {
       cursor: '-webkit-grabbing; -moz-grabbing;',
       axis: 'y',
       forcePlaceholderSize: true,
+      forceHelperSize: true,
       revert: 150,
       helper: function(e, ui) {
         ui.children().each(function() {


### PR DESCRIPTION
### Product areas affected

Screen -> App Data -> Data Sources -> Security Rules -> Reorder Rules

### What does this PR do?

Implemented fix so that width of reordering row matched with width of columns and table

### JIRA ticket

[JIRA](https://weboo.atlassian.net/browse/XOR-431)

### Result

[XOR-Test-431+.webm](https://user-images.githubusercontent.com/108272606/188591043-b3ed69af-33c6-45e4-a63a-084e3487513e.webm)


### Checklist

none

### Testing instructions

none

### Deployment instructions

none

### Author concerns

none