### PR TITLE
ID-2827 [Fix] Do not allow the first row to be moved

### DIFF
--- a/js/spreadsheet.js
+++ b/js/spreadsheet.js
@@ -561,9 +561,9 @@ function spreadsheet(options) {
         return false;
       }
 
-      // First row is moved. Cancel action.
+      // Column header row is moved. Cancel action.
       if (movedRows.indexOf(0) > -1) {
-        console.info('The first row cannot be moved');
+        console.info('Column header row cannot be moved');
 
         return false;
       }


### PR DESCRIPTION
Ref. https://weboo.atlassian.net/browse/ID-2827

See https://handsontable.com/docs/javascript-data-grid/api/hooks/#beforerowmove for more