### PR TITLE
Fix/DEV-250: Ensures all deleted entries remain in localStorage until they are removed from the Data List.

### DIFF
--- a/js/interface.js
+++ b/js/interface.js
@@ -734,8 +734,10 @@ function saveCurrentData() {
   currentDataSourceUpdatedAt = TD(new Date(), { format: 'lll', locale: locale });
 
   var payload = getCommitPayload(entries);
-  var deletedEntries = payload.delete;
   var deletedEntriesKey = 'deleted-entries-' + currentDataSourceId;
+  var deletedEntries = JSON.parse(localStorage.getItem(deletedEntriesKey)) || [];
+
+  deletedEntries.push(...payload.delete);
 
   localStorage.setItem(deletedEntriesKey, JSON.stringify(deletedEntries));
 
@@ -758,6 +760,8 @@ function saveCurrentData() {
 
     cacheOriginalEntries(entries, clientIdMap);
     table.setData({ columns: columns, rows: entries });
+
+    return fetchCurrentDataSourceEntries();
   });
 }
 

--- a/js/interface.js
+++ b/js/interface.js
@@ -423,6 +423,10 @@ function fetchCurrentDataSourceEntries(entries) {
 
     // On initial load, create an empty spreadsheet as this speeds up subsequent loads
     if (initialLoad) {
+      if (table) {
+        table.destroy();
+      }
+
       table = spreadsheet({ columns: columns, rows: [], initialLoad: true });
 
       setTimeout(function() {
@@ -435,6 +439,10 @@ function fetchCurrentDataSourceEntries(entries) {
         $('#versions').removeClass('hidden');
       }, 0);
     } else {
+      if (table) {
+        table.destroy();
+      }
+
       table = spreadsheet({ columns: columns, rows: rows });
       $('.table-entries').css('visibility', 'visible');
 
@@ -673,6 +681,7 @@ function saveCurrentData() {
   var columns;
 
   table.onSave();
+  fetchCurrentDataSourceEntries();
 
   var entries = table.getData({
     parseJSON: true,
@@ -725,6 +734,10 @@ function saveCurrentData() {
   currentDataSourceUpdatedAt = TD(new Date(), { format: 'lll', locale: locale });
 
   var payload = getCommitPayload(entries);
+  var deletedEntries = payload.delete;
+  var deletedEntriesKey = 'deleted-entries-' + currentDataSourceId;
+
+  localStorage.setItem(deletedEntriesKey, JSON.stringify(deletedEntries));
 
   return currentDataSource.commit({
     entries: payload.entries,


### PR DESCRIPTION
### Product areas affected

Fliplet Widget Data Source

### What does this PR do?

Ensures all deleted entries remain in localStorage until they are removed from the Data List.

### JIRA tickets

[DEV-250](https://weboo.atlassian.net/browse/DEV-250)

[DEV-250]: https://weboo.atlassian.net/browse/DEV-250?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability by ensuring the previous table instance is properly destroyed before creating a new one, preventing potential resource issues.
  * The displayed data now refreshes automatically after saving changes.

* **New Features**
  * Deleted entries are now tracked and stored persistently, allowing a cumulative record of deleted entry IDs for each data source.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->