### PR TITLE
ID-3689 [FIX] render entries table after DOM loaded

### DIFF
--- a/js/interface.js
+++ b/js/interface.js
@@ -264,6 +264,10 @@ function waitUntilSized(selector, callback) {
   const el = document.querySelector(selector);
 
   function check() {
+    if (!el || !document.contains(el)) {
+      return;
+    }
+    
     const rect = el.getBoundingClientRect();
     if (rect.width > 0 && rect.height > 0) {
       callback();
@@ -278,7 +282,7 @@ function waitUntilSized(selector, callback) {
 function renderSpreadsheet(rowsData) {
   waitUntilSized('.table-entries', () => {
     table = spreadsheet({ columns: columns, rows: rowsData });
-    $('.table-entries').css('visibility', 'visible');
+    $('.table-entries').css('visibility', 'visible').removeAttr('aria-busy');
     $('#versions').removeClass('hidden');
   });
 }
@@ -446,7 +450,7 @@ function fetchCurrentDataSourceEntries(entries) {
 
     // On initial load, create an empty spreadsheet as this speeds up subsequent loads
     if (initialLoad) {
-      $('.table-entries').css('visibility', 'hidden');
+      $('.table-entries').css('visibility', 'hidden').attr('aria-busy', 'true');
 
       if (table) {
         table.destroy();


### PR DESCRIPTION
### Product areas affected

Fliplet Widget Data Source

### What does this PR do?

Ensures data source entries table is only rendered after other DOM elements are loaded.  

### Notes

The issue reported in the ticket where table is rendered blank was not reproduced. 
When a datasource with large number of entries was loaded a visible flicker can be seen on the UI where the table is rendered blank similar to the issue reported in the ticket. I have resolved that flicker as part of this PR and this will hopefully also resolve the permanent blank table issue as well.

### JIRA tickets

[ID-3689](https://weboo.atlassian.net/browse/ID-3689)


[ID-3689]: https://weboo.atlassian.net/browse/ID-3689?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Spreadsheet now waits for the table container to be sized before rendering, reducing flicker and showing a complete view instantly.
  * Versions section is automatically displayed once data loads.

* **Bug Fixes**
  * Prevents premature rendering that caused empty or partially sized tables.
  * Eliminates layout thrashing during initial data load and refreshes.

* **Refactor**
  * Centralised rendering flow and added a sizing-wait helper to ensure consistent behaviour across initial and subsequent loads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->