### PR TITLE
fix/PS-1375: Ensures the Data Source opens without errors when moving from one to another.

### DIFF
--- a/js/spreadsheet.js
+++ b/js/spreadsheet.js
@@ -13,6 +13,7 @@ function spreadsheet(options) {
   var dataHasChanges = false;
   var columnNameCounter = 1; // Counter to anonymous columns names
   var rendered = 0;
+  var isDestroyed = false; // Flag to prevent actions after instance is destroyed
 
   /**
    * Given an array of data source entries it does return an array
@@ -391,7 +392,15 @@ function spreadsheet(options) {
     afterColumnSort: function() {
       // Applies fix from https://github.com/handsontable/handsontable/pull/5134 for Handsontable 4.0.0
       setTimeout(function() {
-        hot.view.wt.draw(true);
+        if (isDestroyed || !hot || !hot.view || !hot.view.wt || typeof hot.view.wt.draw !== 'function') {
+          return;
+        }
+
+        try {
+          hot.view.wt.draw(true);
+        } catch (e) {
+          // Ignore draw attempts after destroy
+        }
       }, 0);
     },
     search: true,
@@ -768,6 +777,7 @@ function spreadsheet(options) {
 
     var content = td.innerHTML;
     var wrapper = document.createElement('div');
+
     wrapper.classList.add('cell-wrapper');
 
     // Handle objects and arrays
@@ -785,10 +795,19 @@ function spreadsheet(options) {
     // Force recalculation after a small delay to ensure proper height
     if (rendered) {
       setTimeout(function() {
+        if (isDestroyed) {
+          return;
+        }
+
         var contentHeight = wrapper.scrollHeight;
+
         if (contentHeight > 23) { // Default minimum height
-          instance.getSettings().rowHeights[row] = contentHeight + 8; // Add padding
-          instance.render();
+          try {
+            instance.getSettings().rowHeights[row] = contentHeight + 8; // Add padding
+            instance.render();
+          } catch (e) {
+            // Ignore render attempts after destroy
+          }
         }
       }, 0);
     }
@@ -985,7 +1004,22 @@ function spreadsheet(options) {
     destroy: function() {
       reset(true);
 
-      return hot.destroy();
+      // Ensure we do not call methods on a destroyed Handsontable instance
+      if (hot && typeof hot.destroy === 'function') {
+        try {
+          hot.destroy();
+        } catch (e) {
+          // Fail silently; we are cleaning up regardless
+        }
+      }
+
+      // Mark as destroyed to stop any deferred work
+      isDestroyed = true;
+
+      // Nullify reference so external callers can guard with `if (!hot)`
+      hot = null;
+
+      return;
     },
     reset: reset,
     onSave: onSave,


### PR DESCRIPTION
### Product areas affected

Fliplet Widget Data Source

### What does this PR do?

Ensures the Data Source opens without errors when moving from one to another.

### JIRA ticket

[PS-1375](https://weboo.atlassian.net/browse/PS-1375)

[PS-1375]: https://weboo.atlassian.net/browse/PS-1375?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Prevents operations after a spreadsheet is destroyed, reducing errors during sorting and cell height updates.
  - Improves teardown reliability to avoid crashes or inconsistent states when closing a spreadsheet.
- Refactor
  - Strengthens lifecycle guards to ensure deferred work doesn’t run after destruction.
- Style
  - Minor formatting tidy-up with no functional impact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->