### PR TITLE
DEV-558 [Feat] Added access rules JSON editor to interface to configure operator rules for Security rules

### DIFF
--- a/interface.html
+++ b/interface.html
@@ -221,6 +221,17 @@
                     </div>
                   </div>
                   <div class="form-group">
+                    <div class="col-sm-4 control-label">
+                      <label for="access-rules-json">Security rules JSON</label>
+                      <p class="help-block">Paste the JSON configuration for access rules. Saving settings will overwrite the current security rules.</p>
+                    </div>
+                    <div class="col-sm-8">
+                      <div class="checkbox checkbox-icon">
+                        <textarea class="form-control form-code" id="access-rules-json" rows="15" placeholder="[]"></textarea>
+                      </div>
+                    </div>
+                  </div>
+                  <div class="form-group">
                     <hr />
                     <button class="btn text-danger" data-delete-source>Move to trash</button>
                   </div>

--- a/js/interface.js
+++ b/js/interface.js
@@ -80,6 +80,11 @@ var customRuleEditor = CodeMirror.fromTextArea($('#custom-rule')[0], {
   lineNumbers: true,
   mode: 'javascript'
 });
+var accessRulesEditor = CodeMirror.fromTextArea($('#access-rules-json')[0], {
+  lineNumbers: true,
+  mode: 'javascript'
+});
+
 
 var emptyColumnNameRegex = /^Column\s\([0-9]+\)$/;
 
@@ -290,6 +295,7 @@ function renderSpreadsheet(rowsData) {
 function fetchCurrentDataSourceDetails() {
   definitionEditor.setValue('');
   hooksEditor.setValue('');
+  accessRulesEditor.setValue('[]');
 
   return Fliplet.DataSources.getById(currentDataSourceId, { cache: false }).then(function(dataSource) {
     $settings.find('#id').html(dataSource.id);
@@ -300,9 +306,12 @@ function fetchCurrentDataSourceDetails() {
     }
 
     currentDataSourceType = dataSource.type;
-    currentDataSourceRules = dataSource.accessRules;
-    currentFinalRules = dataSource.accessRules;
+    var accessRules = Array.isArray(dataSource.accessRules) ? dataSource.accessRules : [];
+    currentDataSourceRules = Array.isArray(dataSource.accessRules) ? _.cloneDeep(dataSource.accessRules) : dataSource.accessRules;
+    currentFinalRules = Array.isArray(dataSource.accessRules) ? _.cloneDeep(dataSource.accessRules) : dataSource.accessRules;
     currentDataSourceDefinition = dataSource.definition || {};
+
+    accessRulesEditor.setValue(JSON.stringify(accessRules, null, 2));
 
     if (dataSource.apps && dataSource.apps.length > 0) {
       dataSourceIsLive = _.some(dataSource.apps, function(app) {
@@ -1552,6 +1561,7 @@ $('#app')
     var bundle = !$('#bundle').is(':checked');
     var definition = definitionEditor.getValue();
     var hooks = hooksEditor.getValue();
+    var accessRulesValue = accessRulesEditor.getValue();
 
     $settings.find('#name').parents(':eq(1)').removeClass('has-error');
 
@@ -1586,6 +1596,39 @@ $('#app')
       return;
     }
 
+    var trimmedAccessRules = (accessRulesValue || '').trim();
+    var accessRulesData;
+
+    if (trimmedAccessRules) {
+      try {
+        var parsedAccessRules = JSON.parse(accessRulesValue);
+      } catch (e) {
+        Fliplet.Navigate.popup({
+          popupTitle: 'Invalid settings',
+          popupMessage: 'Access rules must be a valid JSON'
+        });
+
+        return;
+      }
+
+      if (Array.isArray(parsedAccessRules)) {
+        accessRulesData = parsedAccessRules;
+      } else if (parsedAccessRules && typeof parsedAccessRules === 'object' && Array.isArray(parsedAccessRules.accessRules)) {
+        accessRulesData = parsedAccessRules.accessRules;
+      } else {
+        Fliplet.Navigate.popup({
+          popupTitle: 'Invalid access rules',
+          popupMessage: 'Access rules JSON must be an array or an object containing an "accessRules" array.'
+        });
+
+        return;
+      }
+    } else {
+      accessRulesData = [];
+    }
+
+    var formattedAccessRules = JSON.stringify(accessRulesData, null, 2);
+
     try {
       hooks.forEach(function(hook) {
         if (typeof hook.type !== 'string' || !hook.type) {
@@ -1618,9 +1661,13 @@ $('#app')
       name: name,
       bundle: bundle,
       definition: definition,
-      hooks: hooks
+      hooks: hooks,
+      accessRules: accessRulesData
     })
       .then(function() {
+        currentDataSourceRules = _.cloneDeep(accessRulesData);
+        currentFinalRules = _.cloneDeep(accessRulesData);
+        accessRulesEditor.setValue(formattedAccessRules);
         // Update name on UI
         $('.editing-data-source-name').text(name);
 
@@ -1830,6 +1877,7 @@ $('#show-settings').click(function() {
   setTimeout(function() {
     definitionEditor.refresh();
     hooksEditor.refresh();
+    accessRulesEditor.refresh();
   }, 0);
 });
 
@@ -2777,6 +2825,10 @@ function updateDataSourceRules() {
   return Fliplet.DataSources.update(currentDataSourceId, {
     accessRules: currentDataSourceRules
   }).then(function() {
+    var formattedRules = JSON.stringify(Array.isArray(currentDataSourceRules) ? currentDataSourceRules : [], null, 2);
+
+    currentFinalRules = _.cloneDeep(currentDataSourceRules);
+    accessRulesEditor.setValue(formattedRules);
     $saveButton.html(buttonLabel).removeClass('disabled').addClass('hidden');
 
     Fliplet.Modal.alert({


### PR DESCRIPTION
### Product areas affected

Studio/API - Data Source Security rule, API endpoints for data source operations

- `interface.html `- Added a JSON text area to configure DS security rule
- `js/interface.js` - Updated code to pass DS security rule JSON for DS update endpoint 

### What does this PR do?

This PR adds field-level operator restrictions to Data Source security, addressing the critical vulnerabilities identified in [PS-1097](https://weboo.atlassian.net/browse/PS-1097).

- Lets users configure security rules that restrict which Sequelize operators (e.g., $like, $iLike, $gt, $type) can be used on specific fields.
- Applies across all CRUD operations.
- Prevents unauthorized data access patterns by enforcing granular, per-field operator controls.

### JIRA ticket

[DEV-558](https://weboo.atlassian.net/browse/DEV-558).

### Result

https://www.loom.com/share/10d8d31c03634e2bb214f7dfbf1845a6?sid=6bb7694f-c1f8-41ed-b7a7-e62991278b69