### PR TITLE
feat: rename apps → projects (v3 user-visible wording)

### DIFF
--- a/interface.html
+++ b/interface.html
@@ -14,7 +14,7 @@
             <div class="col-sm-8">
               <button data-create-source class="btn-round btn btn-primary">Create new data source</button>
               <button data-show-all-source class="btn-round btn btn-secondary hidden">Show all data sources</button>
-              <button data-app-source class="btn-round btn btn-secondary hidden">Show app's data sources</button>
+              <button data-app-source class="btn-round btn btn-secondary hidden">Show project's data sources</button>
             </div>
             <div class="flex col-sm-4">
               <button data-show-source class="active-source btn-round btn">All</button>
@@ -32,7 +32,7 @@
                 <th class="asc sortable" data-order-name data-default-order="asc">
                   Data source
                 </th>
-                <th>Used by apps</th>
+                <th>Used by projects</th>
                 <th width="200">Available offline</th>
                 <th width="200" class="desc sortable sorted" data-order-date data-default-order="desc">
                   Last updated
@@ -50,7 +50,7 @@
                 <th class="asc sortable" data-trash-name data-default-order="asc">
                   Data source
                 </th>
-                <th>Used by apps</th>
+                <th>Used by projects</th>
                 <th width="200" class="desc sortable" data-trash-date data-default-order="desc">
                   Last updated
                 </th>
@@ -276,7 +276,7 @@
               <div id="access-rules-list">
                 <div class="empty-data-source-rules callout callout-primary hidden">
                   <h4>No security rules found</h4>
-                  <p>Apps will not be able to access this data source until security rules are added.</p>
+                  <p>Projects will not be able to access this data source until security rules are added.</p>
                 </div>
                 <table class="table-hover">
                   <thead>
@@ -366,12 +366,12 @@
             <div class="row">
               <div class="col-md-4">
                 <h5>Applies to</h5>
-                <p>Select apps affected by this rule.</p>
+                <p>Select projects affected by this rule.</p>
               </div>
               <div class="col-md-8 side vertical">
                 <div>
-                  <button data-apps="all" type="button" class="btn btn-default selected">All apps</button>
-                  <button data-apps="filter" type="button" class="btn btn-default"><i class="fa fa-filter fa-fw"></i> Specific apps</button>
+                  <button data-apps="all" type="button" class="btn btn-default selected">All projects</button>
+                  <button data-apps="filter" type="button" class="btn btn-default"><i class="fa fa-filter fa-fw"></i> Specific projects</button>
                 </div>
                 <div class="apps-list"></div>
               </div>

--- a/js/interface.js
+++ b/js/interface.js
@@ -121,7 +121,7 @@ function getDataSources() {
 
         $btnShowAllSource.removeClass('hidden');
         $('[data-app-source]').addClass('hidden');
-        $('[data-back]').text('See all my app\'s data sources');
+        $('[data-back]').text('See all my project\'s data sources');
         $helpIcon.addClass('hidden');
 
         // Filters data sources
@@ -1408,7 +1408,7 @@ $('#app')
     });
 
     if (currentDS && currentDS.apps && currentDS.apps.length) {
-      var appPrefix = currentDS.apps.length > 1 ? 'apps: ' : 'app: ';
+      var appPrefix = currentDS.apps.length > 1 ? 'projects: ' : 'project: ';
       var appUsedIn = currentDS.apps.map(function(elem) {
         return elem.name;
       });
@@ -2404,7 +2404,7 @@ $('#show-access-rules').click(function() {
 
             return app && app.name;
           })).join(', ')
-          : 'All apps',
+          : 'All projects',
         require: rule.require
           ? rule.require.map(function(require) {
             if (typeof require === 'string') {
@@ -2752,7 +2752,7 @@ function updateDataSourceRules() {
     $saveButton.html(buttonLabel).removeClass('disabled').addClass('hidden');
 
     Fliplet.Modal.alert({
-      message: 'Your changes have been applied to all affected apps.'
+      message: 'Your changes have been applied to all affected projects.'
     });
   }).catch(function(error) {
     $saveButton.html(buttonLabel).removeClass('disabled');


### PR DESCRIPTION
## Summary

Replaces #269 with a clean branch based directly on `production`. Same rename work, but without the unrelated master-only commits (PS-1781 pagination, PS-864 security rules, Production #264) that were pulled in by the previous branch.

User-visible "Apps → Projects" rename to align with the v3 Studio rename shipped in Fliplet/fliplet-studio#8518.

## Scope (11 strings across 2 files)

- `interface.html`: "Show app's data sources", "Used by apps" (x2), "Apps will not be able to access", "All apps" / "Specific apps" rule scope, "Select apps affected by this rule"
- `js/interface.js`: "See all my app's data sources", "apps:" / "app:" inline references, "All apps" describer, "applied to all affected apps"

## What was kept

- Runtime end-user app references (e.g. "live users accessing the app", "app size", "make your app smaller") — these refer to the installed runtime app on a user's device
- CSS classes (`.apps-list`), data attributes (`data-app-source`, `data-apps`)
- API paths (`v1/apps/tokens`), Handlebars properties (`{{apps}}`, `{{#each apps}}`)
- `app-overlay` context flag (internal)

🤖 Generated with [Claude Code](https://claude.com/claude-code)