### PR TITLE
fix(PR-9): commit only changed rows from the Data Source Manager

### DIFF
--- a/js/interface.js
+++ b/js/interface.js
@@ -314,7 +314,12 @@ function fetchCurrentDataSourceUsers() {
 }
 
 /**
- * Cache a list of entries as original entries for comparison when committing changes
+ * Cache a list of entries as original entries for comparison when committing changes.
+ * The cached `order` is the visual row index (position in this list), not the raw
+ * stored `order` value — this matches how table.getData() re-derives order at save
+ * time, so an unchanged row compares equal instead of being re-sent (PR-9). Without
+ * this, a page's rows carry their global stored order (e.g. 500–999 on page 2) while
+ * getData() reports 0–499, and every row is falsely flagged as changed.
  * @param {Array} entries - Entries to be cached as original entries
  * @param {Object} [clientIdMap] - Optional map of client IDs to new entry IDs to map add the missing entry IDs. This mutates the entries provided.
  * @returns {undefined}
@@ -322,12 +327,16 @@ function fetchCurrentDataSourceUsers() {
 function cacheOriginalEntries(entries, clientIdMap) {
   entryMap.original = {};
 
-  _.forEach(entries, function(entry) {
+  _.forEach(entries, function(entry, index) {
     if (!entry.id && typeof clientIdMap === 'object') {
       entry.id = clientIdMap[entry.clientId];
     }
 
-    entryMap.original[entry.id] = _.pick(entry, ['id', 'data', 'order']);
+    entryMap.original[entry.id] = {
+      id: entry.id,
+      data: entry.data,
+      order: index
+    };
   });
 }
 

--- a/js/pagination.js
+++ b/js/pagination.js
@@ -43,12 +43,80 @@ var Pagination = (function() {
   }
 
   /**
+   * Normalise a single cell value for change-detection.
+   * The spreadsheet round-trips every value through a text grid (getData +
+   * parseCellValue), so a number stored as 30 comes back as the string "30",
+   * and a blank cell comes back as "" — comparing the raw values would flag
+   * those as changes even though the user changed nothing. We coerce scalars
+   * to their string form and treat null/undefined/"" alike as "blank".
+   * @param {*} value - Raw cell value
+   * @returns {String} Canonical string form ("" for blanks)
+   */
+  function normalizeValue(value) {
+    if (value === null || typeof value === 'undefined') {
+      return '';
+    }
+
+    // Arrays/objects: compare structurally via a stable serialisation
+    if (typeof value === 'object') {
+      return JSON.stringify(value);
+    }
+
+    return String(value);
+  }
+
+  /**
+   * Build a canonical, comparable representation of an entry's data.
+   * Blank fields are dropped so an empty cell and an absent column compare
+   * equal, and keys are sorted so key order never affects the comparison.
+   * @param {Object} data - Entry data object
+   * @returns {Object} Normalised data map
+   */
+  function normalizeData(data) {
+    var normalized = {};
+
+    Object.keys(data || {}).sort().forEach(function(key) {
+      var value = normalizeValue(data[key]);
+
+      if (value !== '') {
+        normalized[key] = value;
+      }
+    });
+
+    return normalized;
+  }
+
+  /**
+   * Determine whether a table entry differs from its cached original.
+   * A row counts as changed when its data content changed OR its position
+   * (order) changed — mirroring what the /commit endpoint actually persists
+   * (it only rewrites order when entry.order !== existing.order).
+   * Comparing the whole entry object (the previous behaviour) produced false
+   * positives because getData() re-derives `order` as the visual row index and
+   * re-parses cell types, so unchanged rows never compared equal and every row
+   * was re-sent on every save (PR-9).
+   * @param {Object} entry - Current entry from the table
+   * @param {Object} original - Cached original entry
+   * @param {Function} isEqualFn - Deep equality comparison function
+   * @returns {Boolean} True if the entry should be committed
+   */
+  function hasEntryChanged(entry, original, isEqualFn) {
+    if (!isEqualFn(normalizeData(entry.data), normalizeData(original.data))) {
+      return true;
+    }
+
+    // Position change (reorder). Guard on a defined order to mirror the API,
+    // which only updates order when a value is supplied.
+    return typeof entry.order !== 'undefined' && entry.order !== original.order;
+  }
+
+  /**
    * Compute the commit payload by comparing current entries against original cached entries.
    * Separates entries into inserted, updated, and deleted.
    * NOTE: Mutates entries in place — adds clientId to new entries, deletes id from recovered entries.
    * @param {Array} entries - Current entries from the table
    * @param {Object} originalMap - Map of entry ID → original entry (from cacheOriginalEntries)
-   * @param {Function} isEqualFn - Deep equality comparison function (e.g. _.isEqual)
+   * @param {Function} isEqualFn - Deep equality comparison function (e.g. _.isEqual), applied to normalised data
    * @param {Function} guidFn - Function to generate unique client IDs
    * @returns {Object} { entries: [...inserted, ...updated], delete: [...deletedIds] }
    */
@@ -92,7 +160,7 @@ var Pagination = (function() {
         return;
       }
 
-      if (!isEqualFn(entry, original)) {
+      if (hasEntryChanged(entry, original, isEqualFn)) {
         updated.push(entry);
       }
     });

--- a/test/pagination.test.js
+++ b/test/pagination.test.js
@@ -244,4 +244,70 @@ describe('Pagination.computeCommitPayload', function() {
     expect(payload.entries).toHaveLength(0);
     expect(payload.delete).toHaveLength(0);
   });
+
+  // PR-9: the original stored a value as a number (e.g. via API/DIS), but the
+  // spreadsheet round-trips it back through getData() as the string "30".
+  // These must NOT be treated as a change, or every such row is re-sent.
+  it('does not flag a number/string round-trip as a change (PR-9 type coercion)', function() {
+    var originals = {
+      1: { id: 1, data: { age: 30, active: true }, order: 0 }
+    };
+    var entries = [
+      { id: 1, data: { age: '30', active: 'true' }, order: 0 }
+    ];
+
+    var payload = Pagination.computeCommitPayload(entries, originals, deepEqual, mockGuid);
+
+    expect(payload.entries).toHaveLength(0);
+    expect(payload.delete).toHaveLength(0);
+  });
+
+  // PR-9: a blank cell ("") and a column that was never set must compare equal —
+  // the truthy-empty trap. Otherwise adding an empty column re-sends every row.
+  it('does not flag a blank cell vs an absent column as a change (PR-9 empty trap)', function() {
+    var originals = {
+      1: { id: 1, data: { name: 'Alice' }, order: 0 }
+    };
+    var entries = [
+      { id: 1, data: { name: 'Alice', note: '' }, order: 0 }
+    ];
+
+    var payload = Pagination.computeCommitPayload(entries, originals, deepEqual, mockGuid);
+
+    expect(payload.entries).toHaveLength(0);
+    expect(payload.delete).toHaveLength(0);
+  });
+
+  // PR-9: reorder must still be persisted — a row whose position (order) changed
+  // is sent even when its data is untouched. Guards against dropping order awareness.
+  it('flags rows whose position (order) changed even when data is unchanged', function() {
+    var originals = {
+      1: { id: 1, data: { name: 'Alice' }, order: 0 },
+      2: { id: 2, data: { name: 'Bob' }, order: 1 }
+    };
+    var entries = [
+      { id: 2, data: { name: 'Bob' }, order: 0 },   // Bob moved up
+      { id: 1, data: { name: 'Alice' }, order: 1 }  // Alice moved down
+    ];
+
+    var payload = Pagination.computeCommitPayload(entries, originals, deepEqual, mockGuid);
+
+    expect(payload.entries).toHaveLength(2);
+    expect(payload.delete).toHaveLength(0);
+  });
+
+  // PR-9: a genuine content edit is still detected after normalisation.
+  it('still detects a real content change after normalisation', function() {
+    var originals = {
+      1: { id: 1, data: { age: 30 }, order: 0 }
+    };
+    var entries = [
+      { id: 1, data: { age: '31' }, order: 0 }
+    ];
+
+    var payload = Pagination.computeCommitPayload(entries, originals, deepEqual, mockGuid);
+
+    expect(payload.entries).toHaveLength(1);
+    expect(payload.entries[0].data.age).toBe('31');
+  });
 });


### PR DESCRIPTION
## Summary
The Data Source Manager re-sent **every visible row** to `POST /commit` on every save — even when nothing changed — defeating the goal of PR-9. The change-diff (`computeCommitPayload`, added with PS-1781 pagination in #268) compared the **whole entry** with `_.isEqual`, but the two sides are produced by different pipelines:

- `getData()` re-derives `order` as the **visual row index** (0…n per page) and re-parses cell types (a stored number `30` comes back as the string `"30"`).
- The cached original held the **raw stored `order`** (e.g. 500–999 on page 2) and raw types.

So an unchanged row never compared equal and was flagged as an update. This fixes it by comparing **normalized data content + position**, and caching the original `order` in the same visual-index coordinate `getData()` uses.

Fixes [PR-9](https://weboo.atlassian.net/browse/PR-9)

## Acceptance criteria
- [x] No-change save sends **0 rows** — `js/pagination.js` `hasEntryChanged()` returns false when normalized data and order both match
- [x] Number/string round-trip (`30` vs `"30"`) not flagged — test `PR-9 type coercion` *(fails without the fix)*
- [x] Blank cell `""` vs absent column not flagged — test `PR-9 empty trap` *(fails without the fix)*
- [x] Reorder still persisted — test `flags rows whose position (order) changed`
- [x] Insert / update / delete behaviour unchanged — existing 19-test suite still green

## Test plan
- [ ] Open a DS, **Save with no edits** → Network tab: `POST …/commit` body has `entries: []` (before: all rows sent)
- [ ] **Page 2** of a >500-row DS, Save with no edits → `entries: []` (before: 500 rows re-sent, which also overwrote global `order`)
- [ ] Edit one cell → exactly that row sent; drag-reorder rows → only the moved rows sent
- [ ] Numeric / boolean / blank cells → not falsely re-sent

## Verification (automated)
- Tests: **23 passed, 0 failed** (`npx jest`) — 2 new tests fail on the pre-fix code, proving they cover the change
- Lint: `js/pagination.js` clean. `js/interface.js` has one **pre-existing** parse error (`column => column.trim()`, present on master) unrelated to this change
- KB pattern match: `computeCommitPayload` / `cacheOriginalEntries` confirmed as the DSM commit path

## Notes / follow-ups (not in scope)
- `cacheOriginalEntries` still runs in a deferred `setTimeout(…, 0)` at load; a save fired before it runs would diff against a stale snapshot. Not introduced or worsened here — worth a separate ticket.
- Structural ops the ticket itself calls out as inherently all-rows (add/rename/delete column) are intentionally unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[PR-9]: https://weboo.atlassian.net/browse/PR-9?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ