### PR TITLE
ID-3689: Reapply blank/empty data source manager fix on production

### DIFF
--- a/js/interface.js
+++ b/js/interface.js
@@ -261,6 +261,34 @@ function renderError(options) {
   });
 }
 
+function waitUntilSized(selector, callback) {
+  var el = document.querySelector(selector);
+
+  function check() {
+    if (!el || !document.contains(el)) {
+      return;
+    }
+
+    var rect = el.getBoundingClientRect();
+
+    if (rect.width > 0 && rect.height > 0) {
+      callback();
+    } else {
+      requestAnimationFrame(check);
+    }
+  }
+
+  check();
+}
+
+function renderSpreadsheet(rowsData) {
+  waitUntilSized('.table-entries', function() {
+    table = spreadsheet({ columns: columns, rows: rowsData });
+    $('.table-entries').css('visibility', 'visible');
+    $('#versions').removeClass('hidden');
+  });
+}
+
 function fetchCurrentDataSourceDetails() {
   definitionEditor.setValue('');
   hooksEditor.setValue('');
@@ -428,24 +456,17 @@ function fetchCurrentDataSourceEntries(entries) {
 
       table = spreadsheet({ columns: columns, rows: [], initialLoad: true });
 
-      setTimeout(function() {
+      requestAnimationFrame(function() {
         table.destroy();
         initialLoad = false;
-
-        table = spreadsheet({ columns: columns, rows: rows });
-        $('.table-entries').css('visibility', 'visible');
-
-        $('#versions').removeClass('hidden');
-      }, 0);
+        renderSpreadsheet(rows);
+      });
     } else {
       if (table) {
         table.destroy();
       }
 
-      table = spreadsheet({ columns: columns, rows: rows });
-      $('.table-entries').css('visibility', 'visible');
-
-      $('#versions').removeClass('hidden');
+      renderSpreadsheet(rows);
     }
   })
     .catch(function onFetchError(error) {


### PR DESCRIPTION
## JIRA Issue
https://weboo.atlassian.net/browse/ID-3689

## Summary
- `production` never had the original ID-3689 fix (PR #249, merged to `master` 2025-09-10) — it's 32 commits behind `master` and predates that fix entirely.
- Separately, a same-day branch-merge mishap on 2025-11-25 ([PR #264](https://github.com/Fliplet/fliplet-widget-data-source/pull/264), "Merge production into master") silently stripped the fix back out of `master` too, so neither branch has had it live since.
- Reapplies the fix unchanged: `waitUntilSized()` polls via `requestAnimationFrame` until `.table-entries` has real dimensions before Handsontable initializes, replacing the blind `setTimeout(fn, 0)` that raced the container's layout and produced a blank/0-height table.

## Testing
- `node --check js/interface.js` — syntax valid
- Diff isolated to the two render branches in `fetchCurrentDataSourceEntries` + two new helper functions (`waitUntilSized`, `renderSpreadsheet`); no other logic touched
- Not browser-verified — reproducing this needs a live Studio+app+DSM session, and the ticket's own repro (resize DSM overlay while toggling DevTools dock) is only ~50% reliable even manually. Recommend QA re-run that repro against this PR.

## Testing notes
1. Open any app's Data Source Manager in Studio, load a data source → the entries table should always render with visible rows, never blank/empty.
2. With DevTools open and docked to the bottom, open a data source, then resize the DevTools panel a few times while the DSM is loading → the table should still render correctly instead of showing an empty/collapsed grid.
3. Close and reopen the DSM overlay a few times in a row on the same data source → table should render every time, no blank state.

## Risk Assessment
- Risk Level: LOW (code) / operational note: targets `production` directly, single-file, reapplies an already-proven fix — see risk assessment in the linked ticket discussion
- Files Modified: 1 (`js/interface.js`)
- Type: Bug fix (regression reapplication)

🤖 Generated with [Claude Code](https://claude.com/claude-code)