### PR TITLE
ID-3689: Restore blank/empty data source manager render-race fix on master

### DIFF
--- a/js/interface.js
+++ b/js/interface.js
@@ -269,6 +269,36 @@ function renderError(options) {
   });
 }
 
+function waitUntilSized(selector, callback) {
+  var el = document.querySelector(selector);
+
+  function check() {
+    if (!el || !document.contains(el)) {
+      return;
+    }
+
+    var rect = el.getBoundingClientRect();
+
+    if (rect.width > 0 && rect.height > 0) {
+      callback();
+    } else {
+      requestAnimationFrame(check);
+    }
+  }
+
+  check();
+}
+
+function renderSpreadsheet(rowsData) {
+  waitUntilSized('.table-entries', function() {
+    table = spreadsheet({ columns: columns, rows: rowsData });
+    $('.table-entries').css('visibility', 'visible');
+    $('.page-loading-overlay').addClass('hidden');
+    $('#versions').removeClass('hidden');
+    updatePaginationControls();
+  });
+}
+
 function fetchCurrentDataSourceDetails() {
   definitionEditor.setValue('');
   hooksEditor.setValue('');
@@ -538,28 +568,17 @@ function fetchCurrentDataSourceEntries(entries) {
 
       table = spreadsheet({ columns: columns, rows: [], initialLoad: true });
 
-      setTimeout(function() {
+      requestAnimationFrame(function() {
         table.destroy();
         initialLoad = false;
-
-        table = spreadsheet({ columns: columns, rows: rows });
-        $('.table-entries').css('visibility', 'visible');
-        $('.page-loading-overlay').addClass('hidden');
-
-        $('#versions').removeClass('hidden');
-        updatePaginationControls();
-      }, 0);
+        renderSpreadsheet(rows);
+      });
     } else {
       if (table) {
         table.destroy();
       }
 
-      table = spreadsheet({ columns: columns, rows: rows });
-      $('.table-entries').css('visibility', 'visible');
-      $('.page-loading-overlay').addClass('hidden');
-
-      $('#versions').removeClass('hidden');
-      updatePaginationControls();
+      renderSpreadsheet(rows);
     }
   })
     .catch(function onFetchError(error) {


### PR DESCRIPTION
## JIRA Issue
https://weboo.atlassian.net/browse/ID-3689

## Why this exists
The original ID-3689 fix ([PR #249](https://github.com/Fliplet/fliplet-widget-data-source/pull/249)) was merged to `master` on 2025-09-10 and lived there ~2.5 months. It was then **silently dropped** when [PR #264](https://github.com/Fliplet/fliplet-widget-data-source/pull/264) merged `production` → `master` on 2025-11-25 (CodeRabbit's own summary of #264: *"Removed `waitUntilSized`/`renderSpreadsheet` helpers and switched requestAnimationFrame-based sequencing to `setTimeout(..., 0)`"*). The later pagination work ([PR #268](https://github.com/Fliplet/fliplet-widget-data-source/pull/268)) built on top of that already-regressed code, so `master` has shipped without the fix since.

This PR restores the fix on `master` **in lockstep with the production hotfix ([PR #273](https://github.com/Fliplet/fliplet-widget-data-source/pull/273))**, so the next release cut from `master` doesn't regress it a third time.

## Root cause (traced, not assumed)
- `.table-entries` has no CSS height — it's set imperatively by `windowResized()` (runs inside `Promise.all([entries, details]).then()` in `browseDataSource`).
- The entries table is built inside `fetchCurrentDataSourceEntries().then()` via `setTimeout(0)` — a separate, parallel promise chain.
- When entries resolves before details, the table is built **before** `windowResized()` sets the height → Handsontable measures a 0-height container → blank (`height:0` on `wtHolder`, as Tony diagnosed in 2023). Nondeterministic ordering = the ~50% "random" repro.

`waitUntilSized()` removes the ordering dependency entirely: it waits (via `requestAnimationFrame`) until `.table-entries` actually has dimensions before mounting the table.

## Changes
- Re-add `waitUntilSized()` and `renderSpreadsheet()` helpers.
- Both initial-load and subsequent-load branches now render via `renderSpreadsheet()`.
- **Adapted for pagination** (the difference vs. the production hotfix): `renderSpreadsheet()` keeps the `.page-loading-overlay` hide and `updatePaginationControls()` call inside the sized-gate, so paginated navigation is unaffected.

## Testing
- `node --check js/interface.js` — syntax valid
- `npm test` — **19/19 pagination tests pass** (unchanged; the fix doesn't touch `js/pagination.js`)
- Diff limited to the render path + two helper functions

## Testing notes
1. Open any app's Data Source Manager, open a data source → the entries table always renders with visible rows, never blank/empty.
2. Open a data source with multiple pages of entries, click Next/Prev and use the page-jump input → each page renders correctly, the "Loading page…" overlay clears, and pagination controls update.
3. With DevTools open and docked to the bottom, open a data source and resize the DevTools panel while it loads → table still renders instead of showing an empty/collapsed grid.
4. Close and reopen the DSM overlay a few times on the same data source → table renders every time.

## Risk Assessment
- Risk Level: LOW — restores an already-proven fix; single file; pagination behavior preserved and tested
- Files Modified: 1 (`js/interface.js`)
- Type: Bug fix (regression restoration)

🤖 Generated with [Claude Code](https://claude.com/claude-code)