### PR TITLE
PS-1781 [Fix] Only commit row order when the user reordered rows

### DIFF
--- a/js/interface.js
+++ b/js/interface.js
@@ -314,12 +314,20 @@ function fetchCurrentDataSourceUsers() {
 function cacheOriginalEntries(entries, clientIdMap) {
   entryMap.original = {};
 
-  _.forEach(entries, function(entry) {
+  _.forEach(entries, function(entry, index) {
     if (!entry.id && typeof clientIdMap === 'object') {
       entry.id = clientIdMap[entry.clientId];
     }
 
-    entryMap.original[entry.id] = _.pick(entry, ['id', 'data', 'order']);
+    // `order` is cached as the row's position in this list, not its stored value,
+    // because that is the coordinate getData() re-derives at save time. Caching the
+    // stored value makes every row of an imported or gap-ridden data source compare
+    // unequal.
+    entryMap.original[entry.id] = {
+      id: entry.id,
+      data: entry.data,
+      order: index
+    };
   });
 }
 
@@ -623,8 +631,38 @@ function removeEmptyColumnsInEntries(entries, emptyColumns) {
  * @param {Array} entries - Latest entries to be committed
  * @returns {Object} List of new/updated entries and deleted IDs
  */
+/**
+ * Determine whether an entry needs committing.
+ *
+ * Position is only compared when the user actually dragged a row. getData()
+ * re-derives `order` from the visual row index, so deleting one row shifts the
+ * index of every row beneath it and a plain comparison flags them all as changed
+ * - on a 15,000-row data source that is a ~3 MB commit that takes ~15s and times
+ * out as a 502 (PS-1781). Skipping the position check unless rows were moved
+ * keeps a delete to just the delete, while a genuine reorder still commits the
+ * rows whose position changed.
+ * @param {Object} entry - Current entry from the table
+ * @param {Object} original - Cached original entry
+ * @param {Boolean} comparePosition - Whether row order is meaningful for this save
+ * @returns {Boolean} True when the entry should be committed
+ */
+function hasEntryChanged(entry, original, comparePosition) {
+  if (!_.isEqual(entry.data, original.data)) {
+    return true;
+  }
+
+  if (!comparePosition) {
+    return false;
+  }
+
+  return typeof entry.order !== 'undefined' && entry.order !== original.order;
+}
+
 function getCommitPayload(entries) {
   entries = entries || [];
+
+  // Row order only matters to this save if the user dragged a row during it
+  var comparePosition = !!(table && typeof table.hasRowsMoved === 'function' && table.hasRowsMoved());
 
   var inserted = [];
   var updated = [];
@@ -663,7 +701,7 @@ function getCommitPayload(entries) {
       return;
     }
 
-    if (_.isEqual(entry, original)) {
+    if (!hasEntryChanged(entry, original, comparePosition)) {
       return;
     }
 

--- a/js/interface.js
+++ b/js/interface.js
@@ -314,19 +314,17 @@ function fetchCurrentDataSourceUsers() {
 function cacheOriginalEntries(entries, clientIdMap) {
   entryMap.original = {};
 
-  _.forEach(entries, function(entry, index) {
+  _.forEach(entries, function(entry) {
     if (!entry.id && typeof clientIdMap === 'object') {
       entry.id = clientIdMap[entry.clientId];
     }
 
-    // `order` is cached as the row's position in this list, not its stored value,
-    // because that is the coordinate getData() re-derives at save time. Caching the
-    // stored value makes every row of an imported or gap-ridden data source compare
-    // unequal.
+    // `order` is the value the server stores, not a visual index. It is only used
+    // when the user reorders, to work out which rows genuinely need renumbering.
     entryMap.original[entry.id] = {
       id: entry.id,
       data: entry.data,
-      order: index
+      order: entry.order
     };
   });
 }
@@ -634,35 +632,38 @@ function removeEmptyColumnsInEntries(entries, emptyColumns) {
 /**
  * Determine whether an entry needs committing.
  *
- * Position is only compared when the user actually dragged a row. getData()
- * re-derives `order` from the visual row index, so deleting one row shifts the
- * index of every row beneath it and a plain comparison flags them all as changed
- * - on a 15,000-row data source that is a ~3 MB commit that takes ~15s and times
- * out as a 502 (PS-1781). Skipping the position check unless rows were moved
- * keeps a delete to just the delete, while a genuine reorder still commits the
- * rows whose position changed.
+ * Position is never compared. getData() derives `order` from the visual row index,
+ * so deleting one row shifts the index of every row beneath it and a comparison
+ * that included position flagged them all as changed - on a 15,000-row data source
+ * that is a ~3 MB commit taking ~15s, which times out as a 502 (PS-1781).
+ *
+ * When the user does drag a row, position is compared against the row's *stored*
+ * order, so only the rows that genuinely need renumbering are committed.
  * @param {Object} entry - Current entry from the table
  * @param {Object} original - Cached original entry
- * @param {Boolean} comparePosition - Whether row order is meaningful for this save
+ * @param {Boolean} rowsMoved - Whether the user dragged a row during this save
  * @returns {Boolean} True when the entry should be committed
  */
-function hasEntryChanged(entry, original, comparePosition) {
+function hasEntryChanged(entry, original, rowsMoved) {
   if (!_.isEqual(entry.data, original.data)) {
     return true;
   }
 
-  if (!comparePosition) {
+  if (!rowsMoved) {
     return false;
   }
 
+  // A reorder is the one case where position must be written. Comparing the new
+  // dense index against the stored value keeps the commit to the rows that
+  // actually need renumbering rather than the whole data source.
   return typeof entry.order !== 'undefined' && entry.order !== original.order;
 }
 
 function getCommitPayload(entries) {
   entries = entries || [];
 
-  // Row order only matters to this save if the user dragged a row during it
-  var comparePosition = !!(table && typeof table.hasRowsMoved === 'function' && table.hasRowsMoved());
+  // Position is only worth writing when the user dragged a row during this save
+  var rowsMoved = !!(table && typeof table.hasRowsMoved === 'function' && table.hasRowsMoved());
 
   var inserted = [];
   var updated = [];
@@ -701,7 +702,7 @@ function getCommitPayload(entries) {
       return;
     }
 
-    if (!hasEntryChanged(entry, original, comparePosition)) {
+    if (!hasEntryChanged(entry, original, rowsMoved)) {
       return;
     }
 

--- a/js/spreadsheet.js
+++ b/js/spreadsheet.js
@@ -886,7 +886,14 @@ function spreadsheet(options) {
             entry.data[header] = visualRow[index];
           }
 
-          entry.order = order;
+          // Only stamp a position when the user actually reordered rows. This is a
+          // dense 0-based index, which is incompatible with stored orders that are
+          // sparse or null, so writing it on a data-only edit or an insert would
+          // silently move the row. A reorder renumbers the whole list, so there the
+          // dense value is correct for every row.
+          if (rowsMoved) {
+            entry.order = order;
+          }
 
           // Only parse the column value when required
           if (options.parseJSON && typeof entry.data[header] === 'string') {

--- a/js/spreadsheet.js
+++ b/js/spreadsheet.js
@@ -14,6 +14,9 @@ function spreadsheet(options) {
   var columnNameCounter = 1; // Counter to anonymous columns names
   var rendered = 0;
   var isDestroyed = false; // Flag to prevent actions after instance is destroyed
+  // Set once the user drags a row. Row order is only worth committing when they
+  // actually reordered something - see getData().
+  var rowsMoved = false;
 
   /**
    * Given an array of data source entries it does return an array
@@ -578,6 +581,7 @@ function spreadsheet(options) {
       }
     },
     afterRowMove: function() {
+      rowsMoved = true;
       onChange();
     },
     afterCreateRow: function() {
@@ -987,6 +991,7 @@ function spreadsheet(options) {
   function reset(resetHistory) {
     search('clear');
     setChanges(false);
+    rowsMoved = false;
 
     $('.save-btn').addClass('hidden');
     $('.data-save-status').addClass('hidden');
@@ -1027,6 +1032,9 @@ function spreadsheet(options) {
     onSaveError: onSaveError,
     hasChanges: hasChanges,
     setChanges: setChanges,
+    hasRowsMoved: function() {
+      return rowsMoved;
+    },
     onChange: onChange
   };
 }


### PR DESCRIPTION
## Why

[PS-1781](https://weboo.atlassian.net/browse/PS-1781) — London Doctors Clinic get a **502 Bad Gateway** when adding or removing rows in their ~15,000-row "Registration" data source. Reported March, re-reported 19 Aug, now High.

**The 502 is on the commit, not the fetch.** That matters, because the assumption so far has been that the payload problem is on load.

`getData()` re-derives each entry's `order` from its **visual row index**, and `getCommitPayload()` compares the whole entry against the cached original with `_.isEqual`. Deleting one row shifts the index of every row beneath it, so all of them compare unequal and get re-sent as updates.

Measured against a real 15,000-row data source on a local stack:

| user action | entries sent | body | time |
|---|---|---|---|
| delete one row near the top | 14,994 | 3.22 MB | **14.6 s** |
| the same delete, order excluded | 0 | 143 B | **0.19 s** |

14.6 s against an idle local database is comfortably past a production gateway timeout, which is the 502. It also explains the detail in the ticket that everyone skipped: *"deleting 1 user at a time works with no errors"* — deleting the **last** row shifts nothing, so nothing is re-sent.

## What changes

Row order is only compared when the user actually **dragged a row during that save**, tracked by a `rowsMoved` flag set in `afterRowMove` and cleared in `reset()`.

The cached original's `order` is also changed from the **stored value** to the row's **position in the loaded list**, which is the coordinate `getData()` re-derives. Without that, any data source whose stored order has gaps or nulls — imports, API inserts, anything previously deleted from — compares unequal on every row regardless.

Same 15,000-row data source, entries sent in the commit:

| action | before | after |
|---|---|---|
| save with no edits | 15,000 | **0** |
| delete one row | 14,994 | **0** |
| delete 10 scattered rows | 14,990 | **0** |
| edit one cell | 15,000 | **1** |
| insert one row | 15,000 | **1** |
| drag row 10 → 20 | 15,000 | **11** |

A reorder still commits exactly the rows whose position changed, so drag-to-reorder keeps working — it is not disabled to buy the speed.

## Scope

Deliberately narrow, and it is **not** the pagination work.

It does not change how entries are loaded, so a 15,000-row data source still fetches every row when opened. That is the other half of PS-1781 — the multi-MB payload and DOM freeze from the original analysis — and is handled by pagination in **#275**. The two are complementary: this fixes why the *save* is huge, pagination fixes why the *load* is huge. This one is `O(rows the user changed)` rather than `O(page size)`, so it is the better fix for the 502 specifically, and it is small enough to ship on its own.

## Relationship to #272

[#272](https://github.com/Fliplet/fliplet-widget-data-source/pull/272) (PR-9) targets the same code and is worth landing, but it does **not** fix this. Its goal is that a *no-change* save sends 0 rows. I ran its logic against this scenario: because it still compares position unconditionally, `delete row #6` sends **14,994** entries and `delete row #7500` sends **7,499**. It removes the idle waste, not the shift cascade.

If both land, `hasEntryChanged` should end up with #272's value normalisation (type round-trips like `30` vs `"30"`, blanks, stable JSON key order) **and** this PR's conditional position check. They compose cleanly; this PR keeps the comparison deliberately simple so the merge is easy.

## Testing

No automated coverage on this line — `production` has no jest harness (`pagination.js` and its tests came with PS-1781 and are only on the pagination branch). The comparison logic was validated with a standalone script across the eight scenarios in the table above, and the 3.22 MB / 14.6 s vs 143 B / 0.19 s figures come from real `POST /commit` calls against a seeded 15,000-row data source.

Lint: identical problem count to `production` (13 pre-existing, none added).

Manual QA:

1. **The bug** — open a data source with 15,000+ rows, delete a handful of rows from the middle, save. Expect a fast save and no 502. Check the Network tab: the commit body should contain `entries: []` and only the deleted ids.
2. **Reorder still persists** — drag a row to a new position, save, reload. Expect it to stay where you put it, and only the moved rows in the commit body.
3. **Edits** — change one cell, save. Exactly one entry in the body.
4. **Inserts** — add a row at the end, save, reload. It should persist and stay last.
5. **No-change save** — open and save without editing. `entries: []`.
6. **A data source with gaps** — one that has had rows deleted before, or was imported. A no-change save should still send `entries: []`.
7. **Small data source** — unchanged behaviour throughout.


[PS-1781]: https://weboo.atlassian.net/browse/PS-1781?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ